### PR TITLE
Change hasbang to guarantee execution in bash

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 cutstring="DO NOT EDIT BELOW THIS LINE"
 


### PR DESCRIPTION
Use env to ensure bash environment.  

The install.sh script errors out on ubuntu 11.04 since sh is old-school sh not bash, and the '[[' operator is not found.  If script is executed in bash shell, everything runs smoothly.

Gracias!
