### PR TITLE
Fix Linux compatibility for install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,18 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 cutstring="DO NOT EDIT BELOW THIS LINE"
+
+ostype=`uname`
+
+if [ "$ostype" != "Linux" ]; then
+  function tailr {
+    tail -r $1
+  }
+else
+  function tailr {
+    tail $1 | tac
+  }
+fi
 
 for name in *; do
   target="$HOME/.$name"
@@ -11,7 +23,7 @@ for name in *; do
         let "cutline = $cutline - 1"
         echo "Updating $target"
         head -n $cutline "$target" > update_tmp
-        startline=`tail -r "$name" | grep -n -m1 "$cutstring" | sed "s/:.*//"`
+        startline=`tailr "$name" | grep -n -m1 "$cutstring" | sed "s/:.*//"`
         if [[ -n $startline ]]; then
           tail -n $startline "$name" >> update_tmp
         else


### PR DESCRIPTION
Adds a function to determine the correct usage of tail
(or tail + tac) based on os type.

Also incorporated change from issue #6, using /usr/bin/env to determine bash rather than expecting sh to be a symlink like on some systems.

Tested on Ubuntu 11.04 and Debian 6.0.
