### PR TITLE
Fixes loading path for .vimrc.local

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -39,8 +39,8 @@ set expandtab
 set list listchars=tab:»·,trail:·
 
 " Local config
-if filereadable(".vimrc.local")
-  source .vimrc.local
+if filereadable("~/.vimrc.local")
+  source ~/.vimrc.local
 endif
 
 " Use Ack instead of Grep when available


### PR DESCRIPTION
As requested, here's a specific pull request for this.
