### PR TITLE
[#29] Remove bundle exec aliases

### DIFF
--- a/aliases
+++ b/aliases
@@ -20,22 +20,20 @@ alias gci="git pull --rebase && rake && git push"
 
 # Bundler
 alias b="bundle"
-alias be="bundle exec"
-alias bake="bundle exec rake"
 
 # Tests and Specs
 alias t="ruby -I test"
-alias s="bundle exec rspec"
-alias cuc="bundle exec cucumber"
+alias s="rspec"
+alias cuc="cucumber"
 
 # Rubygems
 alias gi="gem install"
 alias giv="gem install -v"
 
 # Rails
-alias migrate="bundle exec rake db:migrate db:test:prepare"
-alias remigrate="bundle exec rake db:migrate db:migrate:redo db:schema:dump db:test:prepare"
-alias remongrate="bundle exec rake mongoid:migrate mongoid:migrate:redo"
+alias migrate="rake db:migrate db:test:prepare"
+alias remigrate="rake db:migrate db:migrate:redo db:schema:dump db:test:prepare"
+alias remongrate="rake mongoid:migrate mongoid:migrate:redo"
 
 # Heroku staging
 alias staging='heroku run console --remote staging'


### PR DESCRIPTION
Mmost of us are using `bundle --binstubs` now:

http://robots.thoughtbot.com/post/15346721484/use-bundlers-binstubs
