### PR TITLE
[#27] Add git up and git down aliases

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -2,3 +2,6 @@
   default = tracking
 [format]
   pretty = %Cblue%h%Creset %Cgreen[%ar]%Creset (%an) %s
+[alias]
+  up = !git fetch origin && git rebase origin/master
+  down = !git checkout master && git merge @{-1} --ff-only


### PR DESCRIPTION
- Appropriately rebase master into a feature branch.
- Merge a feature branch into master without a merge commit.
- Use up/down symmetry in the alias names.
