### PR TITLE
Add .ackrc

### DIFF
--- a/ackrc
+++ b/ackrc
@@ -1,0 +1,10 @@
+# Search
+--type-set=coffee=.coffee
+--type-set=cucumber=.feature
+--type-set=haml=.haml
+--type-set=sass=.sass,.scss
+
+# Don't search
+--ignore-dir=log
+--ignore-dir=tags
+--ignore-dir=tmp


### PR DESCRIPTION
Certain files, such as Haml, Cucumber, Sass, and Coffeescript are not
searchable by `ack`. The `.ackrc` file adjusts this.
