### PR TITLE
Set tmux to use reattach-to-user-namespace

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -1,4 +1,9 @@
+# improve colors
 set -g default-terminal "screen-256color"
+
+# enable copy-paste http://goo.gl/DN82E
+# enable RubyMotion http://goo.gl/WDlCy
+set -g default-command "reattach-to-user-namespace -l zsh"
 
 # act like vim
 setw -g mode-keys vi


### PR DESCRIPTION
- Improves tmux compatibility with other systems.
- Better copy-paste: http://goo.gl/DN82E.
- Better RubyMotion: http://goo.gl/WDlCy.
