### PR TITLE
Fix tab completion

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -66,7 +66,10 @@ set wildmode=list:longest,list:full
 set complete=.,w,t
 imap <Tab> <C-P>
 
-" Tags
+" Exclude Javascript files in :Rtags via rails.vim due to warnings when parsing
+let g:Tlist_Ctags_Cmd="ctags --exclude='*.js'"
+
+" Index ctags from any project, including those outside Rails
 map <Leader>ct :!ctags -R .<CR>
 
 " Cucumber navigation commands


### PR DESCRIPTION
- Add mapping for tab completion so Ctrl+P isn't necessary.
- Add a mapping to re-index ctags quickly from vim.
- Remove Tlist, which I believe refers to taglist.vim, which is not in
  thoughtbot/dotfiles.
