### PR TITLE
Improve Markdown integration

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -103,3 +103,5 @@ nnoremap <Down> :echoe "Use j"<CR>
 " Treat <li> and <p> tags like the block tags they are
 let g:html_indent_tags = 'li\|p'
 
+" Markdown files end in .md
+au BufRead,BufNewFile *.md set filetype=markdown


### PR DESCRIPTION
- Default Vim configuration detects .md files as modula
- Replaces default config so that .md is detected as markdown
