### PR TITLE
Kill Postgres connection to given database

### DIFF
--- a/bin/kill-db
+++ b/bin/kill-db
@@ -1,0 +1,6 @@
+#!/bin/sh
+#
+# Kill Postgres connection to given database.
+#
+
+ps xa | grep postgres: | grep $1 | grep -v grep | awk '{print $1}' | xargs kill


### PR DESCRIPTION
On occasion, you might suspend/interrupt a process that is using a
particular database. Rather than hunt down where the zombie'd Postgres
connection is, it can be handy to instead run:

```
kill-db rails_app_development
```
