### PR TITLE
Attach to tmux session w/ current directory name

### DIFF
--- a/bin/tat
+++ b/bin/tat
@@ -1,0 +1,6 @@
+#!/bin/sh
+#
+# Attach to tmux session named the same as current directory.
+#
+
+tmux attach -t `basename $PWD`


### PR DESCRIPTION
I've been experimenting with a workflow where I only run long-running
processes in tmux. Examples:

```
zeus start
foreman start
rake (if the full suite takes a long time)
```

tmux (or screen) are good at that: maintaining a long-running process
across shell sessions.

Instead of opening another tmux pane for vim and another for git
commands, Rails generators, test runs, etc., I do all of that outside of
tmux in my normal shell window. Those are all targeted, quick, actions.
They are what I am doing _right now_. It's my workspace.

While experimenting with this process, I noticed, I do jump into tmux
more often. Therefore, I wanted a shorter command for attaching to the
tmux session with the same name as the current directory.
