### PR TITLE
Pass arguments from rspec shell function when not using zeus

### DIFF
--- a/zsh/functions/rspec
+++ b/zsh/functions/rspec
@@ -2,6 +2,6 @@ rspec() {
   if [ -S .zeus.sock ]; then
     zeus rspec "$@"
   else
-    command rspec
+    command rspec "$@"
   fi
 }


### PR DESCRIPTION
- Non-zeus path didn't pass arguments, so it just ran `rspec`
