### PR TITLE
Pass arguments from rake shell function when not using zeus

### DIFF
--- a/zsh/functions/rake
+++ b/zsh/functions/rake
@@ -2,6 +2,6 @@ rake() {
   if [ -S .zeus.sock ]; then
     zeus rake "$@"
   else
-    command rake
+    command rake "$@"
   fi
 }


### PR DESCRIPTION
Non-zeus path didn't pass arguments, so it just ran `rake`.
