### PR TITLE
Set $VISUAL

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -12,8 +12,9 @@ compinit
 # automatically enter directories without cd
 setopt auto_cd
 
-# use vim as an editor
-export EDITOR=vim
+# use vim as the visual editor
+export VISUAL=vim
+export EDITOR=$VISUAL
 
 # aliases
 if [ -e "$HOME/.aliases" ]; then


### PR DESCRIPTION
Most tools look for $VISUAL before $EDITOR, and we tend to want that
anyway. This allows people to customize the two, for example using GUI
vim for $VISUAL and normal vim for $EDITOR, or more extreme: `ex -v` for
$VISUAL and `ex` for $EDITOR.
