### PR TITLE
Update git's push.default from tracking to upstream

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -1,5 +1,5 @@
 [push]
-  default = tracking
+  default = upstream
 [color]
   branch = auto
   diff = auto


### PR DESCRIPTION
The 'tracking' value has been deprecated in favor of 'upstream'.
