### PR TITLE
Revert to default Git log style

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -4,8 +4,6 @@
   branch = auto
   diff = auto
   status = auto
-[format]
-  pretty = %Cblue%h%Creset %Cgreen[%ar]%Creset (%an) %s
 [alias]
   aa = add --all
   am = commit --amend


### PR DESCRIPTION
- Our current style hides message details
- Default style shows details and one-line versions as appropriate
