### PR TITLE
g alias for git

### DIFF
--- a/aliases
+++ b/aliases
@@ -14,7 +14,6 @@ alias e="$EDITOR"
 alias v="$VISUAL"
 
 # git
-alias g="git"
 alias gci="git pull --rebase && rake && git push"
 
 # Bundler

--- a/zsh/functions/g
+++ b/zsh/functions/g
@@ -1,0 +1,12 @@
+# No arguments: `git status`
+# With arguments: acts like `git`
+g() {
+  if [[ $# > 0 ]]; then
+    git $@
+  else
+    git status
+  fi
+}
+
+# Complete g like git
+compdef g=git

--- a/zshrc
+++ b/zshrc
@@ -1,13 +1,13 @@
 # load our own completion functions
 fpath=(~/.zsh/completion $fpath)
 
-for function in ~/.zsh/functions/*; do
-  source $function
-done
-
 # completion
 autoload -U compinit
 compinit
+
+for function in ~/.zsh/functions/*; do
+  source $function
+done
 
 # automatically enter directories without cd
 setopt auto_cd


### PR DESCRIPTION
With arguments, g acts like git.
Without arguments, it runs `git status`.
