### PR TITLE
Always merge with `ff = only`

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -13,9 +13,11 @@
   co = checkout
   create-branch = !sh -c 'git push origin HEAD:refs/heads/$1 && git fetch origin && git branch --track $1 origin/$1 && cd . && git checkout $1' -
   delete-branch = !sh -c 'git push origin :refs/heads/$1 && git remote prune origin && git branch -D $1' -
-  merge-branch = !git checkout master && git merge @{-1} --ff-only
+  merge-branch = !git checkout master && git merge @{-1}
   rebase-origin = !git fetch origin && git rebase origin/master
   st = status
 [core]
   excludesfile = ~/.gitignore
   autocrlf = input
+[merge]
+  ff = only


### PR DESCRIPTION
@jferris:

This has the effect that Git will never implicitly do a merge commit,
including while doing git pull. If I'm unexpectedly out of sync when I git
pull, I get this message:

> fatal: Not possible to fast-forward, aborting.

At that point, I know that I've forgotten to do something in my normal
workflow, and I retrace my steps.

@gylaz:

I like the value of seeing a failure message if a pull (or just merge) fails
due to not being able to get fast-forwarded. Then I can look to see whose
changes went out, that I may have not expected to be there.
