### PR TITLE
Add a config line required by vundle

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -18,6 +18,7 @@ if (&t_Co > 2 || has("gui_running")) && !exists("syntax_on")
 endif
 
 " Declare bundles are handled via Vundle
+filetype off " required!
 set rtp+=~/.vim/bundle/vundle/
 call vundle#rc()
 


### PR DESCRIPTION
Some how this got removed, and highlighting for some files was broken (like .coffee).
