### PR TITLE
Remove --noheading flag from ag execution

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -75,7 +75,7 @@ set list listchars=tab:»·,trail:·
 " Use Ag (https://github.com/ggreer/the_silver_searcher) instead of Grep when
 " available
 if executable("ag")
-  set grepprg=ag\ --noheading\ --nogroup\ --nocolor
+  set grepprg=ag\ --nogroup\ --nocolor
 endif
 
 " Color scheme


### PR DESCRIPTION
The flag isn't needed, and seems to cause strange output.

Output with flag in vim:

```
app/models/group.rb|4| validates :yammer_group_id, :name, presence: true
||·
app/models/event.rb|24| validates :name, presence: ...
```

Output without:

```
app/models/event.rb|24| validates :name, presence: ... 
app/models/event.rb|25| validates :name, length: ...
app/models/event.rb|26| validates :open, inclusion: ...
```
