### PR TITLE
Always rebase interactively with rebase-origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ configuration:
 * Adds a `create-branch` alias to create feature branches.
 * Adds a `delete-branch` alias to delete feature branches.
 * Adds a `merge-branch` alias to merge feature branches into master.
+* Adds an `up` alias to fetch and rebase `origin/master` into the feature
+  branch. Use `git up -i` for interactive rebases.
 
 Shell aliases and scripts:
 

--- a/gitconfig
+++ b/gitconfig
@@ -12,7 +12,6 @@
   delete-branch = !sh -c 'git push origin :refs/heads/$1 && git remote prune origin && git branch -D $1' -
   merge-branch = !git checkout master && git merge @{-1}
   pr = !hub pull-request
-  squash = !git fetch origin && git rebase -i origin/master
   st = status
   up = !git fetch origin && git rebase origin/master
 [core]


### PR DESCRIPTION
There are two use cases for `rebase-origin` during our normal workflow:

1) Rebase frequently to incorporate upstream changes:

```
g rebase-origin
```

   <resolve conflicts>

2) Pre-merge, squash commits like "Fix whitespace" into a small number of
valuable commit(s). Edit commit messages to reveal intent.

```
g rebase-origin
```

   rake
