### PR TITLE
Remove `git br` alias

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -5,7 +5,6 @@
 [alias]
   aa = add --all
   ap = add --patch
-  br = branch
   ca = commit --amend
   ci = commit -v
   co = checkout


### PR DESCRIPTION
I almost never use `git branch`.
