### PR TITLE
Remove `git aa` alias

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -3,7 +3,6 @@
 [color]
   ui = auto
 [alias]
-  aa = add --all
   ap = add --patch
   br = branch
   ca = commit --amend


### PR DESCRIPTION
Encourage the use of `g ap` (`git add --patch`) instead.
