### PR TITLE
Don't use suffix flag for zsh compadd command

### DIFF
--- a/zsh/completion/_rspec
+++ b/zsh/completion/_rspec
@@ -1,3 +1,3 @@
 #compdef rspec
 
-compadd -P spec/ -S _spec.rb `ls spec/**/*_spec.rb | sed -E "s/spec\/|_spec\.rb//g"`
+compadd -P spec/ `ls spec/**/*_spec.rb | sed -E "s/spec\///g"`


### PR DESCRIPTION
- Fixes an issue where tab completing specs that start with the same
  words(s) makes tab completion freak out and stop working.
- The con is that we'll see "_spec.rb" in the output, like:

``` zsh
$ rspec spec/models/
models/calendar_spec.rb
models/event_closer_spec.rb
...
```
