### PR TITLE
Add be alias for bundle exec

### DIFF
--- a/aliases
+++ b/aliases
@@ -18,6 +18,7 @@ alias gci="git pull --rebase && rake && git push"
 
 # Bundler
 alias b="bundle"
+alias be="bundle exec"
 
 # Tests and Specs
 alias t="ruby -I test"


### PR DESCRIPTION
Aliasing `bundle exec` to `be` is a pretty common convention.
