### PR TITLE
Don't remember cursor position for commit messages

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -30,10 +30,10 @@ augroup vimrcEx
   autocmd FileType text setlocal textwidth=78
 
   " When editing a file, always jump to the last known cursor position.
-  " Don't do it when the position is invalid or when inside an event handler
-  " (happens when dropping a file on gvim).
+  " Don't do it for commit messages, when the position is invalid, or when
+  " inside an event handler (happens when dropping a file on gvim).
   autocmd BufReadPost *
-    \ if line("'\"") > 0 && line("'\"") <= line("$") |
+    \ if &ft != 'gitcommit' && line("'\"") > 0 && line("'\"") <= line("$") |
     \   exe "normal g`\"" |
     \ endif
 augroup END


### PR DESCRIPTION
It's not very useful to be dropped into the middle of your diff when
opening a new commit. This change prevents cursor position from being
restored for the `gitcommit` filetype.
