### PR TITLE
Remove reattach-to-user-namespace

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -1,10 +1,6 @@
 # improve colors
 set -g default-terminal 'screen-256color'
 
-# enable copy-paste http://goo.gl/DN82E
-# enable RubyMotion http://goo.gl/WDlCy
-set -g default-command 'reattach-to-user-namespace -l zsh'
-
 # act like vim
 setw -g mode-keys vi
 bind h select-pane -L


### PR DESCRIPTION
This is Mac OS X-specific. Including this line in the dotfiles causes
`tmux` and `tmux new -s new-session` to break with `[exited]`.

I personally don't do copy-pasteable work inside tmux anymore.

I'm sure this is valuable to some of the thoughtbot vim users but I'm 
thinking it better belongs above `DO NOT EDIT BELOW THIS LINE` as custom 
configuration for those users.
