### PR TITLE
Add mappings to switch windows more succinctly

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -120,10 +120,10 @@ set splitbelow
 set splitright
 
 " Quicker window movement
-noremap <C-j> <C-w>j
-noremap <C-k> <C-w>k
-noremap <C-h> <C-w>h
-noremap <C-l> <C-w>l
+nnoremap <C-j> <C-w>j
+nnoremap <C-k> <C-w>k
+nnoremap <C-h> <C-w>h
+nnoremap <C-l> <C-w>l
 
 " configure syntastic syntax checking to check on open as well as save
 let g:syntastic_check_on_open=1


### PR DESCRIPTION
This is very similar to the mappings given in:

http://robots.thoughtbot.com/post/48275867281/vim-splits-move-faster-and-more-naturally
