### PR TITLE
Use Silver Searcher as CtrlP backend

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -59,10 +59,13 @@ set expandtab
 " Display extra whitespace
 set list listchars=tab:»·,trail:·
 
-" Use Ag (https://github.com/ggreer/the_silver_searcher) instead of Grep when
-" available
-if executable("ag")
-  set grepprg=ag\ --nogroup\ --nocolor
+" Use The Silver Searcher https://github.com/ggreer/the_silver_searcher
+if executable('ag')
+  " Use Ag over Grep
+  set grepprg=ag\\ --nogroup\\ --nocolor
+
+  " Use ag in CtrlP for listing files. Lightning fast and respects .gitignore
+  let g:ctrlp_user_command = 'ag %s -l --nocolor -g ""'
 endif
 
 " Color scheme


### PR DESCRIPTION
- Use `ag` as the find method for listing files in CtrlP Vim plugin
- ag indexes and searches far faster than the native engine
- ag also respects .gitignore files on on a per-directory basis, avoiding duplication
