### PR TITLE
Remove double escaped spaces in vimrc

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -62,7 +62,7 @@ set list listchars=tab:»·,trail:·
 " Use The Silver Searcher https://github.com/ggreer/the_silver_searcher
 if executable('ag')
   " Use Ag over Grep
-  set grepprg=ag\\ --nogroup\\ --nocolor
+  set grepprg=ag\ --nogroup\ --nocolor
 
   " Use ag in CtrlP for listing files. Lightning fast and respects .gitignore
   let g:ctrlp_user_command = 'ag %s -l --nocolor -g ""'


### PR DESCRIPTION
- Bash users experience errors when using the double-escaped spaces for the CtrlP-SilverSearcher integration.

Thanks to @adamyonk for raising this issue
