### PR TITLE
Save with Ctrl+S

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -104,6 +104,10 @@ map <Leader>ct :!ctags -R .<CR>
 " Switch between the last two files
 nnoremap <leader><leader> <c-^>
 
+" Save with two keystrokes instead of five
+map <C-s> <esc>:w<CR>
+imap <C-s> <esc>:w<CR>
+
 " Get off my lawn
 nnoremap <Left> :echoe "Use h"<CR>
 nnoremap <Right> :echoe "Use l"<CR>

--- a/zshrc
+++ b/zshrc
@@ -68,3 +68,6 @@ setopt CORRECT CORRECT_ALL
 
 # Enable extended globbing
 setopt EXTENDED_GLOB
+
+# Disable XON/XOFF flow control
+stty -ixon -ixoff


### PR DESCRIPTION
- Save 750,000 keystrokes over a 10-year programming career.
  http://www.youtube.com/watch?v=SkdrYWhh-8s
- In order to make this work, disable XON/XOFF flow control.
  http://dallarosa.tumblr.com/post/31333511717/commandt-and-ctrl-s-on-mac-os-x

Hat tip, @r00k.
