### PR TITLE
Source ~/.zshrc.local if it exists

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -16,11 +16,6 @@ setopt auto_cd
 export VISUAL=vim
 export EDITOR=$VISUAL
 
-# aliases
-if [ -e "$HOME/.aliases" ]; then
-  source "$HOME/.aliases"
-fi
-
 # vi mode
 bindkey -v
 bindkey "^F" vi-cmd-mode
@@ -69,7 +64,8 @@ setopt CORRECT CORRECT_ALL
 # Enable extended globbing
 setopt EXTENDED_GLOB
 
+# aliases
+[[ -f ~/.aliases ]] && source ~/.aliases
+
 # Local config
-if [ -e "$HOME/.zshrc.local" ]; then
-  source "$HOME/.zshrc.local"
-fi
+[[ -f ~/.zshrc.local ]] && source ~/.zshrc.local


### PR DESCRIPTION
Follows the pattern of:
- ~/.aliases.local in ce7ad49
- ~/.gitconfig.local in 8e141fe
- ~/.vimrc.local in a666267

I am using ~/.zshrc.local as a home for `eval "$(rbenv init -)"`.
