### PR TITLE
Git push to current, not upstream

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -1,5 +1,5 @@
 [push]
-  default = upstream
+  default = current
 [color]
   ui = auto
 [alias]


### PR DESCRIPTION
The primary use case for me is to `git push staging` and `git push
production` from the master branch using our typical git workflow:

https://github.com/thoughtbot/guides/tree/master/protocol#deploy
