### PR TITLE
Make the migrate alias faster

### DIFF
--- a/aliases
+++ b/aliases
@@ -28,7 +28,7 @@ alias gi="gem install"
 alias giv="gem install -v"
 
 # Rails
-alias migrate="rake db:migrate && rake db:rollback && rake db:migrate && rake db:test:prepare"
+alias migrate="rake db:migrate db:rollback && rake db:migrate db:test:prepare"
 alias m="migrate"
 alias rk="rake"
 alias s="rspec"


### PR DESCRIPTION
This was loading up the environment four times when it really only needs to
happen twice.
