### PR TITLE
fix relative .aliases.local path

### DIFF
--- a/aliases
+++ b/aliases
@@ -35,4 +35,4 @@ alias s="rspec"
 alias z="zeus"
 
 # Include custom aliases
-[[ -f .aliases.local ]] && source ~/.aliases.local
+[[ -f ~/.aliases.local ]] && source ~/.aliases.local


### PR DESCRIPTION
When I changed my iTerm setting to start in the same working directory as my previous session, I lost my local aliases.  This fixes it and it seems more correct than a relative path that assumes the working directory is the user's home directory.
