### PR TITLE
Add syntax highlighting to certain file types

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -42,6 +42,9 @@ augroup vimrcEx
   autocmd User Rails Rnavcommand config config -glob=**/* -suffix=.rb -default=routes
 
   " Set syntax highlighting for specific file types
+  autocmd BufRead,BufNewFile Appraisals set filetype=ruby
+  autocmd BufRead,BufNewFile config.ru set filetype=ruby
+  autocmd BufRead,BufNewFile *.json set filetype=javascript
   autocmd BufRead,BufNewFile *.md set filetype=markdown
 
   " Enable spellchecking for Markdown


### PR DESCRIPTION
- Syntax highlight `Appraisals` as Ruby. Used especially for our open
  source libraries.
- Syntax highlight rackup (`config.ru`) files as Ruby. Used in all our
  Ruby web apps. Rails apps are rarely touched but some of the Sinatra
  and Middleman apps are occasionally edited.
- Syntax highlight JSON files as JavaScript. Used in our Trail Map.
