### PR TITLE
Remove redundant syntax highlighting

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -43,8 +43,6 @@ augroup vimrcEx
 
   " Set syntax highlighting for specific file types
   autocmd BufRead,BufNewFile Appraisals set filetype=ruby
-  autocmd BufRead,BufNewFile config.ru set filetype=ruby
-  autocmd BufRead,BufNewFile *.json set filetype=javascript
   autocmd BufRead,BufNewFile *.md set filetype=markdown
 
   " Enable spellchecking for Markdown


### PR DESCRIPTION
Newer versions of vim (such as 7.3.923) syntax highlight Rackup and JSON
files correctly. In the interest of keeping the dotfiles slim and our
machines up-to-date, I think the solution is to remove these from dotfiles
and install a newer version of vim in thoughtbot/laptop:

https://github.com/thoughtbot/laptop/pull/118
