### PR TITLE
Remove `merge.ff=only` setting

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -10,6 +10,7 @@
   co = checkout
   create-branch = !sh -c 'git push origin HEAD:refs/heads/$1 && git fetch origin && git branch --track $1 origin/$1 && cd . && git checkout $1' -
   delete-branch = !sh -c 'git push origin :refs/heads/$1 && git remote prune origin && git branch -D $1' -
+  ff = merge --ff-only
   merge-branch = !git checkout master && git merge @{-1}
   pr = !hub pull-request
   st = status
@@ -17,7 +18,5 @@
 [core]
   excludesfile = ~/.gitignore
   autocrlf = input
-[merge]
-  ff = only
 [include]
   path = .gitconfig.local


### PR DESCRIPTION
- add `git ff` alias that does the same thing

It's not possible to do a non-ff merge when `merge.ff=only` is set.
There are certain situations (like merging from upsteam repo) when
merging without ff is desirable.
