### PR TITLE
Cleanup zshrc

### DIFF
--- a/zlogin
+++ b/zlogin
@@ -14,7 +14,7 @@ colors
 export CLICOLOR=1
 
 # expand functions in the prompt
-setopt prompt_subst
+setopt promptsubst
 
 # prompt
 export PS1='$(git_prompt_info)[${SSH_CONNECTION+"%{$fg_bold[green]%}%n@%m:"}%{$fg_bold[blue]%}%~%{$reset_color%}] '

--- a/zshrc
+++ b/zshrc
@@ -9,63 +9,44 @@ for function in ~/.zsh/functions/*; do
   source $function
 done
 
-# automatically enter directories without cd
-setopt auto_cd
+# history settings
+setopt histignoredups
+SAVEHIST=4096
+HISTSIZE=4096
 
-# use vim as the visual editor
-export VISUAL=vim
-export EDITOR=$VISUAL
+# awesome cd movements from zshkit
+setopt autocd autopushd pushdminus pushdsilent pushdtohome cdablevars
+DIRSTACKSIZE=5
+
+# Try to correct command line spelling
+setopt correct correctall
+
+# Enable extended globbing
+setopt extendedglob
+
+# Allow [ or ] whereever you want
+unsetopt nomatch
 
 # vi mode
 bindkey -v
 bindkey "^F" vi-cmd-mode
 bindkey jj vi-cmd-mode
 
-# use incremental search
-bindkey "^R" history-incremental-search-backward
-
-# add some readline keys back
+# handy keybindings
 bindkey "^A" beginning-of-line
 bindkey "^E" end-of-line
-
-# handy keybindings
+bindkey "^R" history-incremental-search-backward
 bindkey "^P" history-search-backward
 bindkey "^Y" accept-and-hold
 bindkey "^N" insert-last-word
 bindkey -s "^T" "^[Isudo ^[A" # "t" for "toughguy"
 
-# expand functions in the prompt
-setopt prompt_subst
-
-# prompt
-export PS1='[${SSH_CONNECTION+"%n@%m:"}%~] '
-
-# ignore duplicate history entries
-setopt histignoredups
-
-# keep TONS of history
-export HISTSIZE=4096
+# use vim as the visual editor
+export VISUAL=vim
+export EDITOR=$VISUAL
 
 # look for ey config in project dirs
 export EYRC=./.eyrc
-
-# automatically pushd
-setopt auto_pushd
-export dirstacksize=5
-
-# awesome cd movements from zshkit
-setopt AUTOCD
-setopt AUTOPUSHD PUSHDMINUS PUSHDSILENT PUSHDTOHOME
-setopt cdablevars
-
-# Try to correct command line spelling
-setopt CORRECT CORRECT_ALL
-
-# Enable extended globbing
-setopt EXTENDED_GLOB
-
-# Allow [ or ] whereever you want
-unsetopt nomatch
 
 # aliases
 [[ -f ~/.aliases ]] && source ~/.aliases


### PR DESCRIPTION
- remove duplicates with zshenv
- order by functions first, then bindings, then exports
- capitalize zsh options for consistency
