### PR TITLE
Don't cache CtrlP results when using ag

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -67,6 +67,9 @@ if executable('ag')
 
   " Use ag in CtrlP for listing files. Lightning fast and respects .gitignore
   let g:ctrlp_user_command = 'ag %s -l --nocolor -g ""'
+
+  " ag is fast enough that CtrlP doesn't need to cache
+  let g:ctrlp_use_caching = 0
 endif
 
 " Color scheme


### PR DESCRIPTION
It gets very annoying to manually force CtrlP to re-index every time I
add a new file. Since ag is so fast, we can turn off caching when it
powers CtrlP without any noticeable impact on search speed.
