### PR TITLE
Add seamless navigation between vim & tmux splits

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -34,5 +34,12 @@ set -g history-limit 10000
 # switch to last pane
 bind-key C-a last-pane
 
+# smart pane switching with awareness of vim splits
+bind -n C-h run "(tmux display-message -p '#{pane_current_command}' | grep -iq vim && tmux send-keys C-h) || tmux select-pane -L"
+bind -n C-j run "(tmux display-message -p '#{pane_current_command}' | grep -iq vim && tmux send-keys C-j) || tmux select-pane -D"
+bind -n C-k run "(tmux display-message -p '#{pane_current_command}' | grep -iq vim && tmux send-keys C-k) || tmux select-pane -U"
+bind -n C-l run "(tmux display-message -p '#{pane_current_command}' | grep -iq vim && tmux send-keys C-l) || tmux select-pane -R"
+bind -n C-\ run "(tmux display-message -p '#{pane_current_command}' | grep -iq vim && tmux send-keys 'C-\\') || tmux select-pane -l"
+
 # Local config
 if-shell "[ -f ~/.tmux.conf.local ]" 'source ~/.tmux.conf.local'

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -8,6 +8,7 @@ call vundle#rc()
 Bundle 'gmarik/vundle'
 
 " Define bundles via Github repos
+Bundle 'christoomey/vim-tmux-navigator'
 Bundle 'croaky/vim-colors-github'
 Bundle 'danro/rename.vim'
 Bundle 'kchmck/vim-coffee-script'


### PR DESCRIPTION
From this blog post:
http://robots.thoughtbot.com/post/53022241323/seamlessly-navigate-vim-and-tmux-splits

It gets very confusing to have a seperate set of key-bindings for
switching between vim-splits and tmux panes.
