### PR TITLE
Globally ignore `.env` file

### DIFF
--- a/gitignore
+++ b/gitignore
@@ -1,6 +1,7 @@
 *.DS_Store
 *.sw[nop]
 .bundle
+.env
 db/*.sqlite3
 log/*.log
 rerun.txt


### PR DESCRIPTION
It is a common practice to store environment variables in a .env file in
development. This file is read by tools such as foreman and dotenv. This
file can contain sensitive information such as secret keys and should
be excluded from version control
