### PR TITLE
Add only trusted projects' bin directory to $PATH

### DIFF
--- a/zshenv
+++ b/zshenv
@@ -1,0 +1,5 @@
+# mkdir .git/safe in the root of repositories you trust
+export PATH=".git/safe/../../bin:$PATH"
+
+# Local config
+[[ -f ~/.zshenv.local ]] && source ~/.zshenv.local


### PR DESCRIPTION
Assuming the binstubs for a project are in the local bin/ directory, you can
even go a step further to add the directory to shell $PATH so that rspec can
be invoked without the bin/ prefix:

```
export PATH="./bin:$PATH"
```

However, doing so on a system that other people have write access to
(such as a shared host) is a security risk.

https://github.com/sstephenson/rbenv/issues/309
