### PR TITLE
Add a commit message template

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -21,3 +21,5 @@
   ff = only
 [include]
   path = .gitconfig.local
+[commit]
+  template = ~/.gitmessage

--- a/gitmessage
+++ b/gitmessage
@@ -1,0 +1,11 @@
+
+
+# 50-character subject line
+# 
+# 72-character wrapped longer description. This should answer:
+# 
+# * Why was this change necessary?
+# * How does it address the problem?
+# * Are there any side effects?
+# 
+# Include a link to the ticket, if any.


### PR DESCRIPTION
Using the `commit.template` setting, read in a commit message template
for each commit. This template is commented out so the commit message
author doesn't need to delete it.

The template serves as a reminder on how to write a better commit
message. The bullets are taken from Caleb's blog post[1]. There is no
_problem_ per se -- we are writing good messages these days -- but it's
handy to be reminded of things to think about. For example, people often
forget to note whether there are any side effects.

This message does not show on `git commit --amend`, only normal `git
commit`.

[1] https://thoughtbot.com/blog/5-useful-tips-for-a-better-commit-message