### PR TITLE
Add git conflicts alias

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -8,8 +8,10 @@
   ca = commit --amend
   ci = commit -v
   co = checkout
+  conflicts = !git ls-files -u | awk '{print $4}' | sort -u
   create-branch = !sh -c 'git push origin HEAD:refs/heads/$1 && git fetch origin && git branch --track $1 origin/$1 && cd . && git checkout $1' -
   delete-branch = !sh -c 'git push origin :refs/heads/$1 && git remote prune origin && git branch -D $1' -
+  edit-conflicts = !$VISUAL `git conflicts`
   merge-branch = !git checkout master && git merge @{-1}
   pr = !hub pull-request
   st = status


### PR DESCRIPTION
List conflicted files in a format that can be used to vim with the conflicted files loaded and in the arglist.

``` bash
vim `git conflicts`
```
