### PR TITLE
The user is able to type [, ],or ?

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -64,6 +64,9 @@ setopt CORRECT CORRECT_ALL
 # Enable extended globbing
 setopt EXTENDED_GLOB
 
+# Allow [ or ] whereever you want
+unsetopt nomatch
+
 # aliases
 [[ -f ~/.aliases ]] && source ~/.aliases
 


### PR DESCRIPTION
There are [many workarounds](http://robots.thoughtbot.com/post/18129303042/how-to-use-arguments-in-a-rake-task) to the

```
zsh: no matches found: ...
```

issue, but let's just stop it at its core: turn off that `nomatch`
functionality.

Apologies to all who enjoy seeing the pun around:

```
% got a light?
zsh: no matches found: light?
```

But all [good shell puns](http://www-users.cs.york.ac.uk/susan/joke/unix.htm) must come to an end.
