### PR TITLE
Only try to install vundle if it's not installed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,5 +14,8 @@ for name in *; do
   fi
 done
 
-git clone https://github.com/gmarik/vundle.git ~/.vim/bundle/vundle
+if [ ! -e ~/.vim/bundle/vundle ]; then
+  git clone https://github.com/gmarik/vundle.git ~/.vim/bundle/vundle
+fi
+
 vim -u ~/.vimrc.bundles +BundleInstall +qa


### PR DESCRIPTION
Prevents error on re-running ./install.sh:

```
fatal: destination path '~/.vim/bundle/vundle' already exists and is
not an empty directory.
```

https://github.com/thoughtbot/dotfiles/issues/195
