### PR TITLE
Spell-check Markdown by type, not file extension

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -48,7 +48,7 @@ augroup vimrcEx
   autocmd BufRead,BufNewFile *.md set filetype=markdown
 
   " Enable spellchecking for Markdown
-  autocmd BufRead,BufNewFile *.md setlocal spell
+  autocmd FileType markdown setlocal spell
 
   " Automatically wrap at 80 characters for Markdown
   autocmd BufRead,BufNewFile *.md setlocal textwidth=80


### PR DESCRIPTION
Previously, only `*.md` files would get spell-checking. This change adds
`*.markdown` and decouples Markdown spell-checking by file extension.

http://robots.thoughtbot.com/vim-spell-checking/
