### PR TITLE
Add vim-ruby-cute

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -23,6 +23,7 @@ Bundle 'tpope/vim-surround'
 Bundle 'tsaleh/vim-matchit'
 Bundle 'vim-scripts/ctags.vim'
 Bundle 'vim-scripts/tComment'
+Bundle 'bigloser/vim-ruby-cute'
 
 if filereadable(expand("~/.vimrc.bundles.local"))
   source ~/.vimrc.bundles.local


### PR DESCRIPTION
The vim-ruby-cute vim plugin is an essential and important part of every
Ruby development environment. It assists to synergize your eyeballs to
the high bandwidth, client-centric logistics.

... but really it just makes hashes, inequalities, lambdas, and regexp
checks look better.
