### PR TITLE
Load rbenv and add trusted binstubs to PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,6 @@ Your `~/.gitconfig.local` might look like this:
 
 Your `~/.zshrc.local` might look like this:
 
-    # load rbenv
-    eval "$(rbenv init -)"
-
     # recommended by brew doctor
     export PATH="/usr/local/bin:/usr/local/sbin:$PATH"
 
@@ -111,6 +108,11 @@ configuration:
 * Adds a `merge-branch` alias to merge feature branches into master.
 * Adds an `up` alias to fetch and rebase `origin/master` into the feature
   branch. Use `git up -i` for interactive rebases.
+
+[Ruby](https://www.ruby-lang.org/en/) configuration:
+
+* Add trusted binstubs to the `PATH`.
+* Load rbenv into the shell, adding shims onto our `PATH`.
 
 Shell aliases and scripts:
 

--- a/zshrc
+++ b/zshrc
@@ -48,6 +48,14 @@ export EDITOR=$VISUAL
 # look for ey config in project dirs
 export EYRC=./.eyrc
 
+# load rbenv if available
+if which rbenv &>/dev/null ; then
+  eval "$(rbenv init - --no-rehash)"
+fi
+
+# mkdir .git/safe in the root of repositories you trust
+export PATH=".git/safe/../../bin:$PATH"
+
 # aliases
 [[ -f ~/.aliases ]] && source ~/.aliases
 


### PR DESCRIPTION
Our expected way of managing Rubies is with rbenv:

https://github.com/thoughtbot/laptop/blob/master/common-components/ruby-environment

This commit loads rbenv in `zshrc` as recommended by the rbenv docs:

https://github.com/sstephenson/rbenv#basic-github-checkout

Assuming the binstubs for a project are in the local bin/ directory, we can
even go a step further to add the directory to shell $PATH so that rspec can
be invoked without the bin/ prefix:

```
export PATH="./bin:$PATH"
```

Doing so on a system that other people have write access to (such as a shared
host) is a security risk:

https://github.com/sstephenson/rbenv/issues/309

The `.git/safe` convention addresses the security problem:

https://twitter.com/tpope/status/165631968996900865
