### PR TITLE
changes 'brew tap thoughtbot/rcm' to 'brew tap thoughtbot/formulae'

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,2 +1,2 @@
-tap thoughtbot/rcm
+tap thoughtbot/formulae
 install rcm


### PR DESCRIPTION
After downloading the dotfiles and running brew bundle I get the following
    Cloning into '/usr/local/Library/Taps/thoughtbot-rcm'...
    remote: Reusing existing pack: 29, done.
    remote: Total 29 (delta 0), reused 0 (delta 0)
    Unpacking objects: 100% (29/29), done.
    Checking connectivity... done
    Tapped 0 formula
    Error: No available formula for rcm 
    Searching taps...
    Error: Command failed: L2:brew install rcm
This was fixed by tapping thoughtbot/formulae.
