### PR TITLE
Be able to :!migrate in Vim

### DIFF
--- a/aliases
+++ b/aliases
@@ -28,7 +28,6 @@ alias gi="gem install"
 alias giv="gem install -v"
 
 # Rails
-alias migrate="rake db:migrate db:rollback && rake db:migrate db:test:prepare"
 alias m="migrate"
 alias rk="rake"
 alias s="rspec"

--- a/bin/migrate
+++ b/bin/migrate
@@ -1,0 +1,7 @@
+#!/bin/sh
+#
+# Migrate up, down, up, and then up for test dataase.
+# In bin/ so it can be called from Vim.
+#
+
+rake db:migrate db:rollback && rake db:migrate db:test:prepare


### PR DESCRIPTION
Move the `migrate` alias to bin/ so it can be invoked from `:!` within Vim
without setting `:set shellcmdflag+=i` (which incurs a performance penalty).
