### PR TITLE
Add local file chaining to zlogin

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Put your customizations in dotfiles appended with `.local`:
 * `~/.tmux.conf.local`
 * `~/.vimrc.local`
 * `~/.vimrc.bundles.local`
+* `~/.zlogin.local`
 * `~/.zshrc.local`
 
 For example, your `~/.aliases.local` might look like this:

--- a/zlogin
+++ b/zlogin
@@ -21,3 +21,6 @@ export PS1='$(git_prompt_info)[${SSH_CONNECTION+"%{$fg_bold[green]%}%n@%m:"}%{$f
 
 # load thoughtbot/dotfiles scripts
 export PATH="$HOME/.bin:$PATH"
+
+# Local config
+[[ -f ~/.zlogin.local ]] && source ~/.zlogin.local


### PR DESCRIPTION
All the other files have .local equivalents, except the newly-created
zlogin. I've created a check for ~/.zlogin.local at the end of the
standard zlogin which sources the file if it exists in the same manner
as zshrc and the other dotfiles.
