### PR TITLE
Add extra option for base pane index for tmuxinator

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -16,6 +16,7 @@ set -g prefix C-a
 
 # start window numbers at 1 to match keyboard order with tmux window order
 set -g base-index 1
+set-window-option -g pane-base-index 1
 
 # renumber windows sequentially after closing any of them
 set -g renumber-windows on


### PR DESCRIPTION
I had issues with tmuxinator not running commands inside of a multi-paned window when I started a new tmux session. Here's a blip of one of my tmuxinator session setup files:

``` yml
windows:
  - editor:
      layout: 8087,238x60,0,0[238x44,0,0,0,238x15,0,45,5]
      panes:
        - vim
        -
```

I could never get the `vim` command (as well as others not shown here) to auto-run in the pane, until I made this change to the dotfiles. I got it off of the [tmuxinator readme](https://github.com/tmuxinator/tmuxinator#base-index), and figured it might be helpful to include it here for more out-of-the-box support
