### PR TITLE
Show only basename and git branch in prompt

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -2,11 +2,11 @@
 git_prompt_info() {
   ref=$(git symbolic-ref HEAD 2> /dev/null)
   if [[ -n $ref ]]; then
-    echo "[%{$fg_bold[green]%}${ref#refs/heads/}%{$reset_color%}]"
+    echo " %{$fg_bold[green]%}${ref#refs/heads/}%{$reset_color%}"
   fi
 }
 setopt promptsubst
-export PS1='$(git_prompt_info)[${SSH_CONNECTION+"%{$fg_bold[green]%}%n@%m:"}%{$fg_bold[blue]%}%~%{$reset_color%}] '
+export PS1='${SSH_CONNECTION+"%{$fg_bold[green]%}%n@%m:"}%{$fg_bold[blue]%}%c%{$reset_color%}$(git_prompt_info) %# '
 
 # load our own completion functions
 fpath=(~/.zsh/completion $fpath)


### PR DESCRIPTION
- Switch order from "[git branch][pathname]" to "basename git branch" to read
  more sentence-like ("I'm working on dotfiles in the the dc-prompt branch.")
  and keep project name in same place (flush left) when switching branches.
- Remove noisy brackets.

Example old:

```
[master][~/dev/thoughtbot/dotfiles]
```

Example new:

```
dotfiles dc-prompt
```
