### PR TITLE
Use default 'complete' Vim setting

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -90,7 +90,6 @@ set numberwidth=5
 " will insert tab at beginning of line,
 " will use completion if not at beginning
 set wildmode=list:longest,list:full
-set complete=.,w,t
 function! InsertTabWrapper()
     let col = col('.') - 1
     if !col || getline('.')[col - 1] !~ '\k'


### PR DESCRIPTION
Default setting is `.,w,b,u,t,i`:
- `.`: scan the current buffer ('wrapscan' is ignored)
- `w`: scan buffers from other windows
- `b`: scan other loaded buffers that are in the buffer list
- `u`: scan the unloaded buffers that are in the buffer list
- `t`: tag completion
- `i`: scan current and included files

The default setting is more likely to find a useful match, and modern machines
can search many open and unloaded buffers without pausing.
