### PR TITLE
Set Vim's colorcolumn to 80 characters

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -83,7 +83,6 @@ highlight Folded  guibg=#0A0A0A guifg=#9090D0
 set textwidth=80
 set colorcolumn=+1
 
-
 " Numbers
 set number
 set numberwidth=5


### PR DESCRIPTION
- We have an 80 character formatting limit
- This makes it obvious where that limit is
