### PR TITLE
Improve zsh history

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -28,8 +28,8 @@ colors
 export CLICOLOR=1
 
 # history settings
-setopt histignoredups
-HISTFILE=~/.zsh_history
+setopt hist_ignore_all_dups inc_append_history
+HISTFILE=~/.zhistory
 HISTSIZE=4096
 SAVEHIST=4096
 


### PR DESCRIPTION
- "to the $HISTFILE incrementally (as soon as they are entered), rather than
  waiting until the shell exits"
- replace any duplicate in the history, not just the previous duplicate: allows
  for a cleaner history
- `.zhistory` is more idiomatic than `.zsh_history`
