### PR TITLE
Remove gi and giv aliases

### DIFF
--- a/aliases
+++ b/aliases
@@ -23,10 +23,6 @@ alias b="bundle"
 alias t="ruby -I test"
 alias cuc="bundle exec cucumber"
 
-# Rubygems
-alias gi="gem install"
-alias giv="gem install -v"
-
 # Rails
 alias migrate="rake db:migrate db:rollback && rake db:migrate db:test:prepare"
 alias m="migrate"


### PR DESCRIPTION
Often mistyping things like `gi tst` causes `gi` alias to trigger the install of
the `tst` gem. This is quite annoying and too close to `git` command which we
run much more often than `gem install`. With bundler we should almost never run
`gem install`.
