### PR TITLE
Remove RSpec -- profile option

### DIFF
--- a/rspec
+++ b/rspec
@@ -1,3 +1,2 @@
 --colour
 --order random
---profile 5


### PR DESCRIPTION
- This option adds a lot of noise to test output
- Extra noise often means scrolling
- The profile includes red, which makes me think tests fail
- Profiling isn't useful when running one or a few tests
- I'm usually not in the mindset of profile tests, so I ignore it
