### PR TITLE
Give personalized files precedence.

### DIFF
--- a/rcrc
+++ b/rcrc
@@ -1,2 +1,2 @@
 EXCLUDES="README.md LICENSE Brewfile"
-DOTFILES_DIRS="$HOME/dotfiles $HOME/dotfiles-local"
+DOTFILES_DIRS="$HOME/dotfiles-local $HOME/dotfiles"


### PR DESCRIPTION
When ordering more than one dotfiles folder in `.rcrc`, the first folder
gets precedence when files have the same name. In the current
configuration, having the shared dotfiles folder comes first prevents
users from being able to override shared functionality for files that
don't allow `.local` versions, like zsh functions or binstubs.

rcm doesn't mind if folders in the path order don't exist, so I'm
suggesting to move the `dotfiles-local` folder first so that if users do
override thoughtbot files with their own (I, for example, have my own
`rspec` function), those files will take precedence and users who
override won't have to carefully check each overwrite warning when they
run `rcup`.
