### PR TITLE
Remove functions wrapping Zeus

### DIFF
--- a/zsh/functions/rake
+++ b/zsh/functions/rake
@@ -1,7 +1,0 @@
-rake() {
-  if [ -S .zeus.sock ]; then
-    zeus rake "$@"
-  else
-    command rake "$@"
-  fi
-}

--- a/zsh/functions/rspec
+++ b/zsh/functions/rspec
@@ -1,7 +1,0 @@
-rspec() {
-  if [ -S .zeus.sock ]; then
-    zeus rspec "$@"
-  else
-    command rspec "$@"
-  fi
-}


### PR DESCRIPTION
Project should be moving over to spring, as this is the 'blessed' approach and
is part of suspenders. Leaving these functions around adds yet another layer
of indirection to consider when trying to run these commands:
- function wrapper
- binstub
- rbenv shim
- actual binary
