### PR TITLE
Let people use arrows

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -109,12 +109,6 @@ map <Leader>ct :!ctags -R .<CR>
 " Switch between the last two files
 nnoremap <leader><leader> <c-^>
 
-" Get off my lawn
-nnoremap <Left> :echoe "Use h"<CR>
-nnoremap <Right> :echoe "Use l"<CR>
-nnoremap <Up> :echoe "Use k"<CR>
-nnoremap <Down> :echoe "Use j"<CR>
-
 " vim-rspec mappings
 nnoremap <Leader>t :call RunCurrentSpecFile()<CR>
 nnoremap <Leader>s :call RunNearestSpec()<CR>


### PR DESCRIPTION
I don't use arrow keys, but this configuration doesn't seem like something
that should be foist upon anyone wanting to use our dotfiles. People wanting
to wane themselves from using the arrow keys can do so by moving this to
`vimrc.local`.
