### PR TITLE
Enable shiftround

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -60,6 +60,7 @@ augroup END
 " Softtabs, 2 spaces
 set tabstop=2
 set shiftwidth=2
+set shiftround
 set expandtab
 
 " Display extra whitespace


### PR DESCRIPTION
With `shiftround` enabled, using `>>` will indent the line to the next
multiple of `shiftwidth`. This is useful when you are indenting improperly
indented code.
