### PR TITLE
Enable forward-history-search in zsh with ^S

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -15,6 +15,9 @@ fpath=(~/.zsh/completion $fpath)
 autoload -U compinit
 compinit
 
+# disable XON/XOFF flow control
+stty -ixon
+
 # load custom executable functions
 for function in ~/.zsh/functions/*; do
   source $function
@@ -52,6 +55,7 @@ bindkey jj vi-cmd-mode
 bindkey "^A" beginning-of-line
 bindkey "^E" end-of-line
 bindkey "^R" history-incremental-search-backward
+bindkey "^S" history-incremental-search-forward
 bindkey "^P" history-search-backward
 bindkey "^Y" accept-and-hold
 bindkey "^N" insert-last-word


### PR DESCRIPTION
I use `^R` a lot in the shell to backward search my history for a command, as I'm sure a lot of developers do. But I usually go so fast that I often pass the one that want. In Bash, you can run `^S` to forward search, but you have to disable terminal flow for it work properly. This would be neat to be in zsh too.

Turning off XON/XOFF flow control allows for forward history searching to work, so that now if I'm using `^R` to search my history for a command, if I pass it, I can run `^S` right away to search get back to that command seamlessly.

What are your thoughts here? Does anyone else feel this would be useful?
