### PR TITLE
Remove test:prepare from migrate alias

### DIFF
--- a/aliases
+++ b/aliases
@@ -24,7 +24,7 @@ alias t="ruby -I test"
 alias cuc="bundle exec cucumber"
 
 # Rails
-alias migrate="rake db:migrate db:rollback && rake db:migrate db:test:prepare"
+alias migrate="rake db:migrate db:rollback && rake db:migrate"
 alias m="migrate"
 alias rk="rake"
 alias s="rspec"


### PR DESCRIPTION
- `rake db:test:prepare` has been depreciated in rails 4.1
