### PR TITLE
Use wildmenu when tab completing filenames in vim

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -87,10 +87,12 @@ highlight Folded  guibg=#0A0A0A guifg=#9090D0
 set number
 set numberwidth=5
 
+" Control tab completion of filenames
+set wildmenu wildmode=longest:full,full
+
 " Tab completion
 " will insert tab at beginning of line,
 " will use completion if not at beginning
-set wildmode=list:longest,list:full
 function! InsertTabWrapper()
     let col = col('.') - 1
     if !col || getline('.')[col - 1] !~ '\k'


### PR DESCRIPTION
Using `wildmenu` prevents the screen from "sliding up" when tab completing filenames (via `:e` or `:b`). It looks cleaner, but has a small disadvantage -- it can display a limited amount of files without further input.

![screen shot 2014-05-07 at 7 17 49 pm](https://cloud.githubusercontent.com/assets/116327/2911223/ffaa6448-d656-11e3-8c46-21b13a2d3544.png)
