### PR TITLE
Run rubocop locally as part of syntastic

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -140,6 +140,9 @@ nnoremap <C-l> <C-w>l
 " configure syntastic syntax checking to check on open as well as save
 let g:syntastic_check_on_open=1
 
+" use Rubocop in syntastic checks
+let g:syntastic_ruby_checkers = ['mri', 'rubocop']
+
 " Local config
 if filereadable($HOME . "/.vimrc.local")
   source ~/.vimrc.local


### PR DESCRIPTION
Syntastic checks for some simple Ruby errors (using `ruby -w -T1-c`) but
we can go further with rubocop checks, too. This will hopefully reduce
the number of commits that exist to appease Hound.
