### PR TITLE
Have Syntastic ignore angular attribute warnings

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -139,6 +139,7 @@ nnoremap <C-l> <C-w>l
 
 " configure syntastic syntax checking to check on open as well as save
 let g:syntastic_check_on_open=1
+let g:syntastic_html_tidy_ignore_errors=[" proprietary attribute \"ng-"]
 
 " Local config
 if filereadable($HOME . "/.vimrc.local")


### PR DESCRIPTION
The Syntastic HTML linter will warn on propriety attributes. The likelihood
that you _accidentally_ typed "ng-repeat" is low. Let's just assume you know
what you're doing and ignore warnings about "ng-*" attributes.
