### PR TITLE
Upgrade `migrate` alias for Rails 4.1

### DIFF
--- a/aliases
+++ b/aliases
@@ -24,7 +24,7 @@ alias t="ruby -I test"
 alias cuc="bundle exec cucumber"
 
 # Rails
-alias migrate="rake db:migrate db:rollback && rake db:migrate db:test:prepare"
+alias migrate="rake db:migrate db:rollback && rake db:migrate"
 alias m="migrate"
 alias rk="rake"
 alias s="rspec"


### PR DESCRIPTION
Rails 4.1 no longer defines `rake db:migrate`:

https://github.com/rspec/rspec-rails/issues/936
