### PR TITLE
tat command now works in directories with periods

### DIFF
--- a/bin/tat
+++ b/bin/tat
@@ -1,6 +1,5 @@
 #!/bin/sh
 #
 # Attach or create tmux session named the same as current directory.
-#
 
-tmux new-session -As `basename $PWD`
+tmux new-session -As "$(basename "$PWD" | tr . -)"


### PR DESCRIPTION
Running `tat` in the robots.thoughtbot.com directory was throwing a
'bad session name' tmux error
