### PR TITLE
Set Vim's spellfile to $HOME

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -146,6 +146,10 @@ nnoremap <C-l> <C-w>l
 let g:syntastic_check_on_open=1
 let g:syntastic_html_tidy_ignore_errors=[" proprietary attribute \"ng-"]
 
+" Set spellfile to location that is guaranteed to exist, can be symlinked to
+" Dropbox or kept in Git and managed outside of thoughtbot/dotfiles using rcm.
+set spellfile=$HOME/.vim-spell-en.utf-8.add
+
 " Local config
 if filereadable($HOME . "/.vimrc.local")
   source ~/.vimrc.local


### PR DESCRIPTION
Running `zg` adds words to the `spellfile`:

4f5a2ed
http://robots.thoughtbot.com/vim-spell-checking

Setting the spellfile keeps it out of its default location, `vim/spell`, which
would otherwise be inside thoughtbot/dotfiles. We don't necessarily want to
share the `spellfile` across the team.
