### PR TITLE
Introduces `git_template` for `git init` templating

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ configuration:
 * Adds a `merge-branch` alias to merge feature branches into master.
 * Adds an `up` alias to fetch and rebase `origin/master` into the feature
   branch. Use `git up -i` for interactive rebases.
+* Adds `post-{checkout,commit,merge}` hooks to re-index your ctags.
+  To extend your `git` hooks, create executable scripts in `~/.git_template.local/hooks/post-{commit,checkout,merge}`
 
 [Ruby](https://www.ruby-lang.org/en/) configuration:
 

--- a/git_template/hooks/ctags
+++ b/git_template/hooks/ctags
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+PATH="/usr/local/bin:$PATH"
+dir="`git rev-parse --git-dir`"
+trap 'rm -f "$dir/$$.tags"' EXIT
+git ls-files | \
+  "${CTAGS:-ctags}" --tag-relative -L - -f"$dir/$$.tags" --languages=-javascript,sql
+mv "$dir/$$.tags" "$dir/tags"

--- a/git_template/hooks/post-checkout
+++ b/git_template/hooks/post-checkout
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+LOCAL_HOOK=$HOME/.git_template.local/hooks/post-checkout
+[[ -f $LOCAL_HOOK ]] && source $LOCAL_HOOK
+
+.git/hooks/ctags >/dev/null 2>&1 &

--- a/git_template/hooks/post-commit
+++ b/git_template/hooks/post-commit
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+LOCAL_HOOK=$HOME/.git_template.local/hooks/post-commit
+[[ -f $LOCAL_HOOK ]] && source $LOCAL_HOOK
+
+.git/hooks/ctags >/dev/null 2>&1 &

--- a/git_template/hooks/post-merge
+++ b/git_template/hooks/post-merge
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+LOCAL_HOOK=$HOME/.git_template.local/hooks/post-merge
+[[ -f $LOCAL_HOOK ]] && source $LOCAL_HOOK
+
+.git/hooks/ctags >/dev/null 2>&1 &

--- a/git_template/hooks/post-rewrite
+++ b/git_template/hooks/post-rewrite
@@ -1,0 +1,4 @@
+#!/bin/sh
+case "$1" in
+  rebase) exec .git/hooks/post-merge ;;
+esac

--- a/gitconfig
+++ b/gitconfig
@@ -1,3 +1,5 @@
+[init]
+  templatedir = ~/.git_template
 [push]
   default = current
 [color]
@@ -10,6 +12,7 @@
   co = checkout
   co-pr = !sh -c 'git fetch origin pull/$1/head:pr/$1 && git checkout pr/$1' -
   create-branch = !sh -c 'git push origin HEAD:refs/heads/$1 && git fetch origin && git branch --track $1 origin/$1 && cd . && git checkout $1' -
+  ctags = "!sh -c '[ -f .git/hooks/ctags ] || git init; .git/hooks/ctags' git-ctags"
   delete-branch = !sh -c 'git push origin :refs/heads/$1 && git branch -D $1' -
   merge-branch = !git checkout master && git merge @{-1}
   pr = !hub pull-request


### PR DESCRIPTION
Inspired by http://tbaggery.com/2011/08/08/effortless-ctags-with-git.html
- Runs `ctag` on `commit` / `branch` / `checkout`
- Extensible via `~/.git_template.local/hooks/{pre,post}-*`
