### PR TITLE
Allow stylesheets to autocomplete hyphenated words

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -52,6 +52,9 @@ augroup vimrcEx
 
   " Automatically wrap at 80 characters for Markdown
   autocmd BufRead,BufNewFile *.md setlocal textwidth=80
+
+  " Allow stylesheets to autocomplete hyphenated words
+  autocmd FileType css,scss,sass setlocal iskeyword+=-
 augroup END
 
 " Softtabs, 2 spaces


### PR DESCRIPTION
This is particularly handy for completing long variable names, such as those used in Bourbon.

Before:

![before](https://cloud.githubusercontent.com/assets/16124/3638916/cdc72546-1068-11e4-81d8-0f5e2db00c04.gif)

After:

![after](https://cloud.githubusercontent.com/assets/16124/3638917/d1803326-1068-11e4-91b8-1c07f60ab486.gif)
