### PR TITLE
Config dirs for vim and zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Put your customizations in dotfiles appended with `.local`:
 * `~/.vimrc.local`
 * `~/.vimrc.bundles.local`
 * `~/.zshrc.local`
+* `~/.zsh/configs/*`
 
 For example, your `~/.aliases.local` might look like this:
 
@@ -78,6 +79,50 @@ Your `~/.vimrc.bundles.local` might look like this:
 
     Plugin 'Lokaltog/vim-powerline'
     Plugin 'stephenmckinney/vim-solarized-powerline'
+
+zsh Configurations
+------------------
+
+Additional zsh configuration can go under the `~/.zsh/configs` directory. This
+has two special subdirectories: `pre` for files that must be loaded first, and
+`post` for files that must be loaded last.
+
+For example, `~/.zsh/configs/pre/virtualenv` makes use of various shell
+features which may be affected by your settings, so load it first:
+
+    # Load the virtualenv wrapper
+    . /usr/local/bin/virtualenvwrapper.sh
+
+Setting a key binding can happen in `~/.zsh/configs/keys`:
+
+    # Grep anywhere with ^G
+    bindkey -s '^G' ' | grep '
+
+Some changes, like `chpwd`, must happen in `~/.zsh/configs/post/chpwd`:
+
+    # Show the entries in a directory whenever you cd in
+    function chpwd {
+      ls
+    }
+
+This directory is handy for combining dotfiles from multiple teams; one team
+can add the `virtualenv` file, another `keys`, and a third `chpwd`.
+
+The `~/.zshrc.local` is loaded after `~/.zsh/configs`.
+
+vim Configurations
+------------------
+
+Similarly to the zsh configuration directory as described above, vim
+automatically loads all files in the `~/.vim/plugin` directory. This does not
+have the same `pre` or `post` subdirectory support that our `zshrc` has.
+
+This is an example `~/.vim/plugin/c.vim`. It is loaded every time vim starts,
+regardless of the file name:
+
+    # Indent C programs according to BSD style(9)
+    set cinoptions=:0,t0,+4,(4
+    autocmd BufNewFile,BufRead *.[ch] setlocal sw=0 ts=8 noet
 
 What's in it?
 -------------

--- a/zshrc
+++ b/zshrc
@@ -75,5 +75,41 @@ export PATH=".git/safe/../../bin:$PATH"
 # aliases
 [[ -f ~/.aliases ]] && source ~/.aliases
 
+# extra files in ~/.zsh/configs/pre , ~/.zsh/configs , and ~/.zsh/configs/post
+# these are loaded first, second, and third, respectively.
+_load_settings() {
+  _dir="$1"
+  if [ -d "$_dir" ]; then
+    if [ -d "$_dir/pre" ]; then
+      for config in "$_dir"/pre/**/(N-.); do
+        . $config
+      done
+    fi
+
+    for config in "$_dir"/**/(N-.); do
+      case "$config" in
+        "$_dir"/pre/*)
+          :
+          ;;
+        "$_dir"/post/*)
+          :
+          ;;
+        *)
+          if [ -f $config ]; then
+            . $config
+          fi
+          ;;
+      esac
+    done
+
+    if [ -d "$_dir/post" ]; then
+      for config in "$_dir"/post/**/(N-.); do
+        . $config
+      done
+    fi
+  fi
+}
+_load_settings "$HOME/.zsh/configs"
+
 # Local config
 [[ -f ~/.zshrc.local ]] && source ~/.zshrc.local


### PR DESCRIPTION
Allow for additional configuration in subdirectories: `~/.vim/configs` and `~/.zsh/configs`.

Under `.vim/configs` you might find: some Swift-specific settings that you and the iOS team are trying; email-specific settings that you and other mutters are sharing; general one-off settings that you want scoped and well-named.

Under `.zsh/configs` you might find: the latest Ruby switcher that you're trying, some cool keybindings that you and your friends can't live without, or Android-specific settings that you're sharing with the other Arch users.

`.zsh/configs` supports a `pre` and `post` subdirectory, so you can have more control over the order in which things load. For example, you may want to set `chpwd` in a `post` subdirectory to prevent odd `cd` behavior while your rc files load.
