### PR TITLE
Allow personal overrides to psqlrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,18 @@ Install [rcm](https://github.com/thoughtbot/rcm):
 
     brew bundle dotfiles/Brewfile
 
-Install:
+Install the dotfiles:
 
-    rcup -d dotfiles -x README.md -x LICENSE -x Brewfile
+    env RCRC=$HOME/dotfiles/rcrc rcup
 
-This will create symlinks for config files in your home directory. The `-x`
-options, which exclude the `README.md`, `LICENSE`, and `Brewfile` files, are
-needed during installation but can be skipped once the `.rcrc` configuration
-file is symlinked in.
+This command will create symlinks for config files in your home directory.
+Setting the `RCRC` environment variable tells `rcup` to use standard
+configuration options:
+
+* Exclude the `README.md`, `LICENSE`, and `Brewfile` files, which are part of
+  the `dotfiles` repository but do not need to be symlinked in.
+* Give precedence to personal overrides which by default are placed in
+  `~/dotfiles-local`
 
 You can safely run `rcup` multiple times to update:
 
@@ -43,6 +47,8 @@ Put your customizations in dotfiles appended with `.local`:
 * `~/.aliases.local`
 * `~/.gitconfig.local`
 * `~/.gvimrc.local`
+* `~/.psqlrc.local` (we supply a blank `.psqlrc.local` to prevent `psql` from
+  throwing an error, but you should overwrite the file with your own copy)
 * `~/.tmux.conf.local`
 * `~/.vimrc.local`
 * `~/.vimrc.bundles.local`

--- a/hooks/post-up
+++ b/hooks/post-up
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+touch $HOME/.psqlrc.local
+
 if [ ! -e $HOME/.vim/bundle/Vundle.vim ]; then
   git clone https://github.com/gmarik/Vundle.vim.git $HOME/.vim/bundle/Vundle.vim
 fi

--- a/psqlrc
+++ b/psqlrc
@@ -21,3 +21,8 @@
 \set HISTCONTROL ignoredups
 \set COMP_KEYWORD_CASE upper
 \unset quiet
+
+-- psql can't check for a file's existence, so we'll provide an empty local
+-- file that users can override with their custom dotfiles. To set your own
+-- personal settings, place your own file in ~/.psqlrc.local
+\i ~/.psqlrc.local


### PR DESCRIPTION
I wanted to add my own customizations after reading @mike-burns' post on [`psqlrc`](http://robots.thoughtbot.com/an-explained-psqlrc), but my brief research indicates that there's not a clean way to sourcea file only after checking to see if the file exists from psql. I think the best solution is to include a blank `psqlrc.local` file so that it can always be sourced, but for users with no overrides it supplies no settings.

Adding a blank `psqlrc.local` file that users can override with their own custom
dotfiles, which will allow users to override the thoughtbot-provided defaults
(while continuing to receive upstream changes) and make their own
personalizations.
