### PR TITLE
Improve ag tab completion

### DIFF
--- a/zsh/completion/_ag
+++ b/zsh/completion/_ag
@@ -1,9 +1,7 @@
 #compdef ag
 
 if (( CURRENT == 2 )); then
-  if [[ -a tmp/tags ]]; then
-    compadd $(cut -f 1 tmp/tags | uniq)
-  fi
+  compadd $(cut -f 1 tmp/tags .git/tags 2>/dev/null)
 else;
   _files
 fi


### PR DESCRIPTION
- Remove unnecessary `uniq`
- Look for tags in tmp/tags or .git/tags
- Send errors to /dev/null if the file(s) do not exist

See http://tbaggery.com/2011/08/08/effortless-ctags-with-git.html for an
explanation behind the reasoning for .git/tags.
