### PR TITLE
\unset QUIET is case sensitive

### DIFF
--- a/psqlrc
+++ b/psqlrc
@@ -20,7 +20,7 @@
 \set HISTFILE ~/.psql_history- :DBNAME
 \set HISTCONTROL ignoredups
 \set COMP_KEYWORD_CASE upper
-\unset quiet
+\unset QUIET
 
 -- psql can't check for a file's existence, so we'll provide an empty local
 -- file that users can override with their custom dotfiles. To set your own


### PR DESCRIPTION
Seems like \unset QUIET and \unset quiet aren't the same. At least in psql 9.3.5, \unset quiet leaves psql in quiet mode (not reporting things like affected-row counts after an update or delete command).
