### PR TITLE
Add more Git hooks, delegate to .local convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Make your own customizations
 Put your customizations in dotfiles appended with `.local`:
 
 * `~/.aliases.local`
+* `~/.git_template.local/*`
 * `~/.gitconfig.local`
 * `~/.gvimrc.local`
 * `~/.psqlrc.local` (we supply a blank `.psqlrc.local` to prevent `psql` from
@@ -78,6 +79,9 @@ Your `~/.zshenv.local` might look like this:
     if which pyenv &>/dev/null ; then
       eval "$(pyenv init -)"
     fi
+
+To extend your `git` hooks, create executable scripts in
+`~/.git_template.local/hooks/*` files.
 
 Your `~/.zshrc.local` might look like this:
 
@@ -171,7 +175,8 @@ configuration:
 * Adds an `up` alias to fetch and rebase `origin/master` into the feature
   branch. Use `git up -i` for interactive rebases.
 * Adds `post-{checkout,commit,merge}` hooks to re-index your ctags.
-  To extend your `git` hooks, create executable scripts in `~/.git_template.local/hooks/post-{commit,checkout,merge}`
+* Adds `pre-commit` and `prepare-commit-msg` stubs that delegate to your local
+  config.
 
 [Ruby](https://www.ruby-lang.org/en/) configuration:
 

--- a/git_template/hooks/pre-commit
+++ b/git_template/hooks/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+local_hook="$HOME"/.git_template.local/hooks/pre-commit
+[ -f "$local_hook" ] && . "$local_hook"

--- a/git_template/hooks/prepare-commit-msg
+++ b/git_template/hooks/prepare-commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+local_hook="$HOME"/.git_template.local/hooks/prepare-commit-msg
+[ -f "$local_hook" ] && . "$local_hook"


### PR DESCRIPTION
The `pre-commit` and `prepare-commit-msg` git hooks can be used for some
interesting things such as linting files. For example:

https://github.com/croaky/dotfiles/commit/b3bc7d3f0dff46a47697c8c81a8352b76eb0e3a5
