### PR TITLE
Remove unused plugins after rcup

### DIFF
--- a/hooks/post-up
+++ b/hooks/post-up
@@ -5,4 +5,4 @@ touch $HOME/.psqlrc.local
 if [ ! -e $HOME/.vim/bundle/Vundle.vim ]; then
   git clone https://github.com/gmarik/Vundle.vim.git $HOME/.vim/bundle/Vundle.vim
 fi
-vim -u $HOME/.vimrc.bundles +PluginInstall +qa
+vim -u $HOME/.vimrc.bundles +PluginInstall +PluginClean! +qa


### PR DESCRIPTION
Running `rcup` should remove any plugins that are no longer in use. For
instance, we recently replaced `rename.vim` with `eunuch`. `rcup` installs the
new plugin but does not clean up `rename` from the plugins directory. The
addition of `PluginClean!` does this (without confirmation).
