### PR TITLE
Load rbenv in zshrc, not zshenv

### DIFF
--- a/zshenv
+++ b/zshenv
@@ -5,11 +5,6 @@ export EDITOR=$VISUAL
 # ensure dotfiles bin directory is loaded first
 export PATH="$HOME/.bin:/usr/local/bin:$PATH"
 
-# load rbenv if available
-if which rbenv &>/dev/null ; then
-  eval "$(rbenv init - --no-rehash)"
-fi
-
 # mkdir .git/safe in the root of repositories you trust
 export PATH=".git/safe/../../bin:$PATH"
 

--- a/zshrc
+++ b/zshrc
@@ -96,5 +96,12 @@ _load_settings() {
 }
 _load_settings "$HOME/.zsh/configs"
 
+# load rbenv if available
+export PATH="$HOME/.rbenv/bin:$PATH"
+
+if which rbenv &>/dev/null ; then
+  eval "$(rbenv init - --no-rehash)"
+fi
+
 # Local config
 [[ -f ~/.zshrc.local ]] && source ~/.zshrc.local


### PR DESCRIPTION
On Mac OS X, there is a bug where `/etc/zshenv`'s `path_helper` forces
`/usr/bin` to the front of the `$PATH`:

https://github.com/sstephenson/rbenv/issues/369

```
# system-wide environment settings for zsh(1)
if [ -x /usr/libexec/path_helper ]; then
  eval `/usr/libexec/path_helper -s`
fi
```

This breaks rbenv by always using the system Ruby.

We have fixed this in the past in our Laptop script by moving `/etc/zshenv` to
`/etc/zprofile`:

https://github.com/thoughtbot/laptop/commit/c64806ec7d5e5111980152fa5a88922450873de3

And more recently, to `/etc/zshrc`:

https://github.com/thoughtbot/laptop/blame/master/mac

On Yosemite with the version of thoughtbot/dotfiles before this commit, with
rbenv being initialized in `~/.zshenv`, the problem returned.

Moving rbenv initialization back to `~/.zshrc` fixed the problem.

The official documentation for rbenv also recommends initializing in
`~/.zshrc`.

https://github.com/sstephenson/rbenv#basic-github-checkout

It also recommends:

```
export PATH="$HOME/.rbenv/bin:$PATH"
```
