### PR TITLE
Use `gh`, not `hub`

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -15,7 +15,7 @@
   ctags = "!sh -c '[ -f .git/hooks/ctags ] || git init; .git/hooks/ctags' git-ctags"
   delete-branch = !sh -c 'git push origin :refs/heads/$1 && git branch -D $1' -
   merge-branch = !git checkout master && git merge @{-1}
-  pr = !hub pull-request
+  pr = !gh pull-request
   st = status
   up = !git fetch origin && git rebase origin/master
 [core]


### PR DESCRIPTION
[gh](https://github.com/jingweno/gh) is a [hub](https://github.com/github/hub) reimplementation that's much faster and
is now the official Github CLI.

It appears that "hub" is [deprecated](github/hub#475):

Matches thoughtbot/laptop:

https://github.com/thoughtbot/laptop/commit/d9a9dfe09bf5898172c752c87be7c5ae6537c5f2
