### PR TITLE
Fix the zsh config glob

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -66,12 +66,12 @@ _load_settings() {
   _dir="$1"
   if [ -d "$_dir" ]; then
     if [ -d "$_dir/pre" ]; then
-      for config in "$_dir"/pre/**/(N-.); do
+      for config in "$_dir"/pre/**/*(N-.); do
         . $config
       done
     fi
 
-    for config in "$_dir"/**/(N-.); do
+    for config in "$_dir"/**/*(N-.); do
       case "$config" in
         "$_dir"/pre/*)
           :
@@ -88,7 +88,7 @@ _load_settings() {
     done
 
     if [ -d "$_dir/post" ]; then
-      for config in "$_dir"/post/**/(N-.); do
+      for config in "$_dir"/post/**/*(N-.); do
         . $config
       done
     fi


### PR DESCRIPTION
The glob used a modifier, but it was modifying a directory instead of a
glob that matched all the files in the directory. Add the missing `*` to
fix this.

Closes #298.
