### PR TITLE
Prevent evil nbsp from being invisible

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -64,7 +64,7 @@ set shiftround
 set expandtab
 
 " Display extra whitespace
-set list listchars=tab:»·,trail:·
+set list listchars=tab:»·,trail:·,nbsp:·
 
 " Use The Silver Searcher https://github.com/ggreer/the_silver_searcher
 if executable('ag')


### PR DESCRIPTION
Not seeing these (Non-breaking spaces) can be problematic, since you won't know what broke your code on the day that one of them sneaks in.

Here's a few other common characters people use for this: https://github.com/search?utf8=%E2%9C%93&q=nbsp%3A+extension%3A.vimrc&type=Code&ref=searchresults
