### PR TITLE
Map `<Leader>a` to vim-rspec's `RunAllSpecs()`

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -125,6 +125,7 @@ nnoremap <Down> :echoe "Use j"<CR>
 nnoremap <Leader>t :call RunCurrentSpecFile()<CR>
 nnoremap <Leader>s :call RunNearestSpec()<CR>
 nnoremap <Leader>l :call RunLastSpec()<CR>
+nnoremap <Leader>a :call RunAllSpecs()<CR>
 
 " Run commands that require an interactive shell
 nnoremap <Leader>r :RunInInteractiveShell<space>


### PR DESCRIPTION
Per the suggested key mappings in [vim-rspec](https://github.com/thoughtbot/vim-rspec).
