### PR TITLE
Updating readme to use thoughtbot/formulae

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,2 +1,0 @@
-tap thoughtbot/formulae
-install rcm

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ updated](http://robots.thoughtbot.com/keeping-a-github-fork-updated)).
 
 Install [rcm](https://github.com/thoughtbot/rcm):
 
-    brew bundle dotfiles/Brewfile
+    brew tap thoughtbot/formulae
+    brew install rcm
 
 Install the dotfiles:
 

--- a/rcrc
+++ b/rcrc
@@ -1,2 +1,2 @@
-EXCLUDES="README.md LICENSE Brewfile"
+EXCLUDES="README.md LICENSE"
 DOTFILES_DIRS="$HOME/dotfiles-local $HOME/dotfiles"


### PR DESCRIPTION
Brew bundle is deprecated. Updating readme instructions to use thoughtbot/formulae.

fixes #309

I tested instructions on a fresh machine. Works perfectly.
