### PR TITLE
Include local gitconfig at the end of .gitconfig

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -23,9 +23,9 @@
   autocrlf = input
 [merge]
   ff = only
-[include]
-  path = .gitconfig.local
 [commit]
   template = ~/.gitmessage
 [fetch]
   prune = true
+[include]
+  path = ~/.gitconfig.local


### PR DESCRIPTION
Not sure if it's by design, but `.gitconfig.local` is currently included before the end of thoughtbot's `.gitconfig`.
Including it at the end of the file allows for further customizing the commit message template.
