### PR TITLE
Revert adding /usr/local/bin to path in zshenv

### DIFF
--- a/zshenv
+++ b/zshenv
@@ -3,7 +3,7 @@ export VISUAL=vim
 export EDITOR=$VISUAL
 
 # ensure dotfiles bin directory is loaded first
-export PATH="$HOME/.bin:/usr/local/bin:$PATH"
+export PATH="$HOME/.bin:$PATH"
 
 # load rbenv if available
 if which rbenv &>/dev/null ; then


### PR DESCRIPTION
- Adding `/usr/local/bin` to path in `~/.zshenv` causes it to be in my path twice one right after the other. `/usr/local/bin` is already added to the path in the correct order on OSX Yosemite by the `/etc/paths` file. 
- Remove /usr/local/bin from path export in zshenv
