### PR TITLE
Wrap at 72 characters for git commit messages

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -53,6 +53,9 @@ augroup vimrcEx
   " Automatically wrap at 80 characters for Markdown
   autocmd BufRead,BufNewFile *.md setlocal textwidth=80
 
+  " Automatically wrap at 72 characters for git commit messages
+  autocmd FileType gitcommit setlocal textwidth=72
+
   " Allow stylesheets to autocomplete hyphenated words
   autocmd FileType css,scss,sass setlocal iskeyword+=-
 augroup END


### PR DESCRIPTION
The body of a git commit message is conventionally ([1](http://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message), [2](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)) wrapped at
72 characters. This commit adjusts .vimrc to automatically wrap the body
of git commit messages at 72 characters.
