### PR TITLE
Ignore tags file, but not directories named tags

### DIFF
--- a/gitignore
+++ b/gitignore
@@ -6,5 +6,6 @@ db/*.sqlite3
 log/*.log
 rerun.txt
 tags
+!tags/
 tmp/**/*
 !tmp/cache/.keep


### PR DESCRIPTION
Has an issue in a Rails project where I had a views/tags folder. Rather than blanket ignoring anything named tags this will prevent edge cases where there might be a tags directory.
