### PR TITLE
Use POSIX compliant test command in git hooks

### DIFF
--- a/git_template/hooks/post-checkout
+++ b/git_template/hooks/post-checkout
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-LOCAL_HOOK=$HOME/.git_template.local/hooks/post-checkout
-[[ -f $LOCAL_HOOK ]] && source $LOCAL_HOOK
+local_hook="$HOME"/.git_template.local/hooks/post-checkout
+[ -f "$local_hook" ] && . "$local_hook"
 
 .git/hooks/ctags >/dev/null 2>&1 &

--- a/git_template/hooks/post-commit
+++ b/git_template/hooks/post-commit
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-LOCAL_HOOK=$HOME/.git_template.local/hooks/post-commit
-[[ -f $LOCAL_HOOK ]] && source $LOCAL_HOOK
+local_hook="$HOME"/.git_template.local/hooks/post-commit
+[ -f "$local_hook" ] && . "$local_hook"
 
 .git/hooks/ctags >/dev/null 2>&1 &

--- a/git_template/hooks/post-merge
+++ b/git_template/hooks/post-merge
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-LOCAL_HOOK=$HOME/.git_template.local/hooks/post-merge
-[[ -f $LOCAL_HOOK ]] && source $LOCAL_HOOK
+local_hook="$HOME"/.git_template.local/hooks/post-merge
+[ -f "$local_hook" ] && . "$local_hook"
 
 .git/hooks/ctags >/dev/null 2>&1 &


### PR DESCRIPTION
One of the students in Metis is running Ubuntu and `/bin/sh` is running as `Dash`. This is erroring out on `[[` in the `post-*` git hook files.

Switching to using POSIX compliant `[` command in place of the Bash specific `[[` per https://wiki.ubuntu.com/DashAsBinSh#A.5B.5B. @pbrisbin Can you take a look to verify my shell syntax is good?

Likely want to update https://github.com/thoughtbot/dotfiles/pull/299 as well if this gets merged in.
