### PR TITLE
Remove reference to `Brewfile` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ This command will create symlinks for config files in your home directory.
 Setting the `RCRC` environment variable tells `rcup` to use standard
 configuration options:
 
-* Exclude the `README.md`, `LICENSE`, and `Brewfile` files, which are part of
-  the `dotfiles` repository but do not need to be symlinked in.
+* Exclude the `README.md` and `LICENSE` files, which are part of the `dotfiles`
+  repository but do not need to be symlinked in.
 * Give precedence to personal overrides which by default are placed in
   `~/dotfiles-local`
 


### PR DESCRIPTION
`Brewfile` was removed in cf10a835.
