### PR TITLE
Map arrow keys to window movements

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -119,12 +119,6 @@ map <Leader>ct :!ctags -R .<CR>
 " Switch between the last two files
 nnoremap <leader><leader> <c-^>
 
-" Get off my lawn
-nnoremap <Left> :echoe "Use h"<CR>
-nnoremap <Right> :echoe "Use l"<CR>
-nnoremap <Up> :echoe "Use k"<CR>
-nnoremap <Down> :echoe "Use j"<CR>
-
 " vim-rspec mappings
 nnoremap <Leader>t :call RunCurrentSpecFile()<CR>
 nnoremap <Leader>s :call RunNearestSpec()<CR>
@@ -141,10 +135,10 @@ set splitbelow
 set splitright
 
 " Quicker window movement
-nnoremap <C-j> <C-w>j
-nnoremap <C-k> <C-w>k
-nnoremap <C-h> <C-w>h
-nnoremap <C-l> <C-w>l
+nnoremap <Down> <C-w>j
+nnoremap <Up> <C-w>k
+nnoremap <Left> <C-w>h
+nnoremap <Right> <C-w>l
 
 " configure syntastic syntax checking to check on open as well as save
 let g:syntastic_check_on_open=1


### PR DESCRIPTION
I agree with the "get off my lawn" motivation of promoting `hjkl` for normal mode movements but it always seemed like a waste to not have the arrow keys mapped to something useful, so why not use them for moving between windows?

Benefits:
- Arrow keys do something useful in insert mode rather than just chastising the user
- Navigating between windows does not require holding down `<Ctrl>`

Potential downsides:
- Less obvious that arrow keys don't move you around in insert mode since no message is echoed. This could be confusing at first, but doesn't take too long to get used to.
- Easier to accidentally change windows if you think you're in insert mode when you're in normal mode. This is less of an issue if you have a theme that makes it obvious what mode you're in and which window has focus.
