### PR TITLE
Update tat script to also work from within tmux

### DIFF
--- a/bin/tat
+++ b/bin/tat
@@ -2,4 +2,29 @@
 #
 # Attach or create tmux session named the same as current directory.
 
-tmux new-session -As "$(basename "$PWD" | tr . -)"
+session_name="$(basename "$PWD" | tr . -)"
+
+not_in_tmux() {
+  [ -z "$TMUX" ]
+}
+
+session_exists() {
+  tmux list-sessions | sed -E 's/:.*$//' | grep -q "^$session_name$"
+}
+
+create_detached_session() {
+  (TMUX='' tmux new-session -Ad -s "$session_name")
+}
+
+create_if_needed_and_attach() {
+  if not_in_tmux; then
+    tmux new-session -As "$session_name"
+  else
+    if ! session_exists; then
+      create_detached_session
+    fi
+    tmux switch-client -t "$session_name"
+  fi
+}
+
+create_if_needed_and_attach


### PR DESCRIPTION
The existing script would fail if run from within tmux as the default
behavior would cause a nested tmux session which is bad. This update
detects if the current context is within tmux and properly handles this
by creating a detached session and switching to it as needed.

This properly handles all four combinations of in tmux vs out, and
session existing vs not. The behavior should remain unchanged for
existing use cases.
