### PR TITLE
Add alias for pretty-printing $PATH

### DIFF
--- a/aliases
+++ b/aliases
@@ -28,5 +28,8 @@ alias m="migrate"
 alias rk="rake"
 alias s="rspec"
 
+# Pretty print the path
+alias path="echo $PATH | tr -s ':' '\n'"
+
 # Include custom aliases
 [[ -f ~/.aliases.local ]] && source ~/.aliases.local


### PR DESCRIPTION
I've had a number of issues with $PATH of late and I kept using this to make
it readable (and comparable).
