### PR TITLE
Remove outdated references to `Rnavcommand`

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -39,10 +39,6 @@ augroup vimrcEx
     \   exe "normal g`\"" |
     \ endif
 
-  " Cucumber navigation commands
-  autocmd User Rails Rnavcommand step features/step_definitions -glob=**/* -suffix=_steps.rb
-  autocmd User Rails Rnavcommand config config -glob=**/* -suffix=.rb -default=routes
-
   " Set syntax highlighting for specific file types
   autocmd BufRead,BufNewFile Appraisals set filetype=ruby
   autocmd BufRead,BufNewFile *.md set filetype=markdown


### PR DESCRIPTION
`Rnavcommand` has been removed from rails.vim. These commands don't work if
you are using a recent version of the plugin. Users who want to regain this
functionality can do it through projections.