### PR TITLE
Don't interpolate environment variables in aliases

### DIFF
--- a/aliases
+++ b/aliases
@@ -10,8 +10,8 @@ alias -g G='| grep'
 alias -g M='| less'
 alias -g L='| wc -l'
 alias -g ONE="| awk '{ print \$1}'"
-alias e="$EDITOR"
-alias v="$VISUAL"
+alias e='$EDITOR'
+alias v='$VISUAL'
 
 # git
 alias gci="git pull --rebase && rake && git push"
@@ -29,7 +29,7 @@ alias rk="rake"
 alias s="rspec"
 
 # Pretty print the path
-alias path="echo $PATH | tr -s ':' '\n'"
+alias path='echo $PATH | tr -s ":" "\n"'
 
 # Include custom aliases
 [[ -f ~/.aliases.local ]] && source ~/.aliases.local


### PR DESCRIPTION
A few aliases contain references to environment variables, but were
defined using double quotes. This caused zsh to interpolate the value of
those variables when the alias was defined instead of when it was
executed. In particular, any change to `PATH` (or `EDITOR` or `VISUAL`)
in `.zshrc.local`, which is sourced after `.aliases`, would not be
reflected in these aliases.

This commit defines these aliases using single quotes so that the
environment variables are evaluated when the alias is executed.