### PR TITLE
Stop ag from excluding directories with ds_store

### DIFF
--- a/gitignore
+++ b/gitignore
@@ -1,4 +1,4 @@
-*.DS_Store
+.DS_Store
 *.sw[nop]
 .bundle
 .env


### PR DESCRIPTION
* Silver searcher or ag was filtering out any directory that had a
  .DS_STORE file. Any directory that has a .DS_STORE file in it is being
  ignored by ag and therefor does not show up in the ctrlp fuzzy finder
  either.
* Removing the * from before .DS_STORE in the gitignore
  file still prevents .DS_STORE files from being checked into source
  control and stops ag from filtering out the directory. I am not sure
  if this is a bug with silver_searcher or what