### PR TITLE
Prevent unreadable prompt within Git repository

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -2,7 +2,7 @@
 git_prompt_info() {
   current_branch=$(git current-branch 2> /dev/null)
   if [[ -n $current_branch ]]; then
-    echo " %{$fg_bold[green]%}%{$current_branch%}%{$reset_color%}"
+    echo " %{$fg_bold[green]%}$current_branch%{$reset_color%}"
   fi
 }
 setopt promptsubst


### PR DESCRIPTION
When within a git repository, doing a tab-autocomplete on a command results with the command becoming unreadable. The command still works but this is pretty annoying visually.

Basically I

1. Navigate to a directory with a git repository in it. The prompt indicates the current branch properly
2. Next, type `git -` and hit tab

The prompt now shows only part of branch's name with the first suggestion appended.

![zsh-prompt-unreadable](https://cloud.githubusercontent.com/assets/37100/6169016/baf5aaf0-b2ca-11e4-826c-e11e1cc19998.gif)

After googling a bit I stumbled upon several pages describing a similar problem (most useful to me was http://stackoverflow.com/questions/23740862/issues-with-zsh-prompt).

The culprit seems to be the git_prompt_info function escaping the `$current_branch` variable as if it is a color. As a result zsh is confused where the cursor is. After "unescaping" the variable everything seems to work fine.

Using zsh 5.0.7 (x86_64-apple-darwin13.4.0).