### PR TITLE
Switch from gh to hub

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -16,7 +16,7 @@
   current-branch = !sh -c 'git rev-parse --abbrev-ref HEAD' -
   delete-branch = !sh -c 'git push origin :refs/heads/$1 && git branch -D $1' -
   merge-branch = !git checkout master && git merge @{-1}
-  pr = !gh pull-request
+  pr = !hub pull-request
   rename-branch = !sh -c 'old=$(git current-branch) && git branch -m $old $1 && git push origin --set-upstream $1 && git push origin --delete $old' -
   st = status
   up = !git fetch origin && git rebase origin/master


### PR DESCRIPTION
* `hub` is the official GitHub client.
* Like `gh`, `hub` 2.2.0 now powered by the Go programming language.
  https://github.com/github/hub/releases/tag/v2.2.0
* It has been bottled in Homebrew.
  Homebrew/homebrew@1ad37e4
* We are using it in the Laptop script.
  https://github.com/thoughtbot/laptop/commit/9fe038cd81d14aed29ed6e8cb242a527cf7b3e89