### PR TITLE
Extend ctags support for Ruby.

### DIFF
--- a/ctags
+++ b/ctags
@@ -1,0 +1,2 @@
+--regex-ruby=/([A-Z][A-Z0-9_]+)[ \t]*=/\1/C,constant/
+--regex-ruby=/^[ \t]*attr_reader :([a-z0-9_]+)/\1/r,attr_reader/


### PR DESCRIPTION
This adds experimental support for attr_reader and constant definitions.
It's quite rough, but a good starting point for improving ctags.

Inspired by this Trello discussion:
https://trello.com/c/liLHC19x/14-improving-tags-in-ctags-files
