### PR TITLE
remove `set nocompatible`

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -1,7 +1,3 @@
-" Use Vim settings, rather then Vi settings. This setting must be as early as
-" possible, as it has side effects.
-set nocompatible
-
 " Leader
 let mapleader = " "
 


### PR DESCRIPTION
It is not needed; Vim sets `nocompatible` automatically when a `vimrc` is found.

See http://vimdoc.sourceforge.net/htmldoc/options.html#'nocompatible', or `:help 'cp'`