### PR TITLE
bin/replace improvement

### DIFF
--- a/bin/replace
+++ b/bin/replace
@@ -9,4 +9,4 @@ shift
 replace_with=$1
 shift
 
-ag -l $find_this $* | xargs sed -i '' "s/$find_this/$replace_with/g"
+ag -l --nocolor $find_this $* | xargs sed -i '' "s/$find_this/$replace_with/g"


### PR DESCRIPTION
for those with an `.ackrc` that sets `--color`, this script will fail.

Set the `--nocolor` flag to make piping `xargs` safe