### PR TITLE
Use vim-plug over vundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ What's in it?
 * Use [Exuberant Ctags](http://ctags.sourceforge.net/) for tab completion.
 * Use [vim-mkdir](https://github.com/pbrisbin/vim-mkdir) for automatically
   creating non-existing directories before writing the buffer.
-* Use [Vundle](https://github.com/gmarik/Vundle.vim) to manage plugins.
+* Use [vim-plug](https://github.com/junegunn/vim-plug) to manage plugins.
 
 [tmux](http://robots.thoughtbot.com/a-tmux-crash-course)
 configuration:

--- a/hooks/post-up
+++ b/hooks/post-up
@@ -2,7 +2,8 @@
 
 touch $HOME/.psqlrc.local
 
-if [ ! -e $HOME/.vim/bundle/Vundle.vim ]; then
-  git clone https://github.com/gmarik/Vundle.vim.git $HOME/.vim/bundle/Vundle.vim
+if [ ! -e $HOME/.vim/autoload/plug.vim ]; then
+  curl -fLo ~/.vim/autoload/plug.vim --create-dirs \
+      https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 fi
-vim -u $HOME/.vimrc.bundles +PluginInstall +PluginClean! +qa
+vim -u $HOME/.vimrc.bundles +PlugInstall +PlugClean! +qa

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -2,36 +2,51 @@ if &compatible
   set nocompatible
 end
 
-filetype off
-set rtp+=~/.vim/bundle/Vundle.vim/
-call vundle#begin()
+" Shim command and function to allow migration from Vundle to vim-plug.
+function! PluginToPlug(arg, ...)
+  echom "You are using Vundle's `Plugin` command to declare plugins. Dotfiles now uses vim-plug for plugin mangagement. Please rename uses of `Plugin` to `Plug`. Plugin was '".a:arg."'."
+  let vim_plug_options = {}
 
-" Let Vundle manage Vundle
-Plugin 'gmarik/Vundle.vim'
+  if a:0 > 0
+    if has_key(a:1, 'name')
+      let name = a:1.name
+      let vim_plug_options.dir = "~/.vim/bundle/".a:1.name
+    endif
+
+    if has_key(a:1, 'rtp')
+      let vim_plug_options.rtp = a:1.rtp
+    endif
+  endif
+
+  Plug a:arg, vim_plug_options
+endfunction
+
+com! -nargs=+  -bar Plugin call PluginToPlug(<args>)
+
+call plug#begin('~/.vim/bundle')
 
 " Define bundles via Github repos
-Plugin 'christoomey/vim-run-interactive'
-Plugin 'kchmck/vim-coffee-script'
-Plugin 'ctrlpvim/ctrlp.vim'
-Plugin 'pbrisbin/vim-mkdir'
-Plugin 'scrooloose/syntastic'
-Plugin 'slim-template/vim-slim'
-Plugin 'thoughtbot/vim-rspec'
-Plugin 'tpope/vim-bundler'
-Plugin 'tpope/vim-endwise'
-Plugin 'tpope/vim-eunuch'
-Plugin 'tpope/vim-fugitive'
-Plugin 'tpope/vim-rails'
-Plugin 'tpope/vim-repeat'
-Plugin 'tpope/vim-surround'
-Plugin 'vim-ruby/vim-ruby'
-Plugin 'vim-scripts/ctags.vim'
-Plugin 'vim-scripts/matchit.zip'
-Plugin 'vim-scripts/tComment'
+Plug 'christoomey/vim-run-interactive'
+Plug 'kchmck/vim-coffee-script'
+Plug 'ctrlpvim/ctrlp.vim'
+Plug 'pbrisbin/vim-mkdir'
+Plug 'scrooloose/syntastic'
+Plug 'slim-template/vim-slim'
+Plug 'thoughtbot/vim-rspec'
+Plug 'tpope/vim-bundler'
+Plug 'tpope/vim-endwise'
+Plug 'tpope/vim-eunuch'
+Plug 'tpope/vim-fugitive'
+Plug 'tpope/vim-rails'
+Plug 'tpope/vim-repeat'
+Plug 'tpope/vim-surround'
+Plug 'vim-ruby/vim-ruby'
+Plug 'vim-scripts/ctags.vim'
+Plug 'vim-scripts/matchit.zip'
+Plug 'vim-scripts/tComment'
 
 if filereadable(expand("~/.vimrc.bundles.local"))
   source ~/.vimrc.bundles.local
 endif
 
-call vundle#end()
-filetype on
+call plug#end()


### PR DESCRIPTION
[vim-plug](https://github.com/junegunn/vim-plug) has a number of advantages over Vundle:

* Installs and updates plugins very quickly in parallel
* Can lock plugins at versions/tags (useful for plugin development)
* Can rollback updates (useful if a plugin breaks) and take/reload snapshots of current plugin state
* Optionally lazily-load plugins when their relevant command is invoked to speed vim start time
* Execute post-update hooks for plugins with compiled extensions, etc.

vim-plug uses a DSL very close to Vundle's (simplest form is `Plug` vs.  `Plugin`), and here it is set to continue to use the same plugin location that Vundle was using before.

After updating, users will need to
1. Rename `Plugin` lines in `.vimrc.bundles.local` to use `Plug`
2. Run `:PlugInstall` (the post-up hook does this automatically)

I am unsure of whether automating renaming in `.vimrc.bundles.local` in a one-time post-up hook (executing it if vim-plug isn't installed at the same time as installing vim-plug) is a good thing to do. For now I've left it out, but if that's needed for widespread support, that would be straightforward to add.