### PR TITLE
Add `regreplop.vim`

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -142,6 +142,12 @@ nnoremap <C-k> <C-w>k
 nnoremap <C-h> <C-w>h
 nnoremap <C-l> <C-w>l
 
+" Remap regreplop's replace operator
+" to not conflict with quick window movement's <C-k>
+nmap <C-[> <Plug>ReplaceMotion
+nmap <C-[><C-[> <Plug>ReplaceLine
+vmap <C-[> <Plug>ReplaceVisual
+
 " configure syntastic syntax checking to check on open as well as save
 let g:syntastic_check_on_open=1
 let g:syntastic_html_tidy_ignore_errors=[" proprietary attribute \"ng-"]

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -28,6 +28,7 @@ Plugin 'tpope/vim-surround'
 Plugin 'vim-ruby/vim-ruby'
 Plugin 'vim-scripts/ctags.vim'
 Plugin 'vim-scripts/matchit.zip'
+Plugin 'vim-scripts/regreplop.vim'
 Plugin 'vim-scripts/tComment'
 
 if filereadable(expand("~/.vimrc.bundles.local"))


### PR DESCRIPTION
See: https://github.com/vim-scripts/regreplop.vim

* Type `<C-[>` followed by a motion to replace (paste over).
* Type `<C-[><C-[>` to paste over the entire line
* Visually select some text, then type `<C-[>` to paste over that text

For example:

Given you have "foobar" copied into your paste register
And your caret is on the `u` in this string: "fizzbuzz"
When you type `<C-[>iw`
Then the string will change from "fizzbuzz" to "foobar"