### PR TITLE
Map <Leader>a in Vim to run all specs

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -121,6 +121,7 @@ nnoremap <Down> :echoe "Use j"<CR>
 nnoremap <Leader>t :call RunCurrentSpecFile()<CR>
 nnoremap <Leader>s :call RunNearestSpec()<CR>
 nnoremap <Leader>l :call RunLastSpec()<CR>
+nnoremap <Leader>a :call RunAllSpecs()<CR>
 
 " Run commands that require an interactive shell
 nnoremap <Leader>r :RunInInteractiveShell<space>


### PR DESCRIPTION
Since we already have key mappings for `RunCurrentSpecFile`,
`RunNearestSpec` and `RunLastSpec`, I thought it would be good idea to
have for `RunAllSpecs` as well. It's using the keys suggested in
https://github.com/thoughtbot/vim-rspec