### PR TITLE
Let ctrl-p find files with a leading dot

### DIFF
--- a/agignore
+++ b/agignore
@@ -1,3 +1,4 @@
 log
 tags
 tmp
+.git/

--- a/vimrc
+++ b/vimrc
@@ -68,7 +68,7 @@ if executable('ag')
   set grepprg=ag\ --nogroup\ --nocolor
 
   " Use ag in CtrlP for listing files. Lightning fast and respects .gitignore
-  let g:ctrlp_user_command = 'ag %s -l --nocolor -g ""'
+  let g:ctrlp_user_command = 'ag %s -l --nocolor --hidden -g ""'
 
   " ag is fast enough that CtrlP doesn't need to cache
   let g:ctrlp_use_caching = 0


### PR DESCRIPTION
I am constantly forgetting that I can't use `ctrl-p` to open
`.travis.yml` or any other file with a leading `.`. This change comes
about after some discussion in general on how to handle this. Passing
`--hidden` to the `ag` command allows it to find files with a leading
`.`.

Unfortunately, this also includes the content of your `.git`
directory. To overcome this, we add `/.git/` to `agignore`.