### PR TITLE
Remove GitHub colorscheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ Your `~/.gitconfig.local` might look like this:
       name = Dan Croak
       email = dan@thoughtbot.com
 
+Your `~/.vimrc.local` might look like this:
+
+    " Color scheme
+    colorscheme github
+    highlight NonText guibg=#060606
+    highlight Folded  guibg=#0A0A0A guifg=#9090D0
+
 Your `~/.zshenv.local` might look like this:
 
     # load pyenv if available
@@ -154,7 +161,6 @@ What's in it?
 * Use [Ag](https://github.com/ggreer/the_silver_searcher) instead of Grep when
   available.
 * Use [Exuberant Ctags](http://ctags.sourceforge.net/) for tab completion.
-* Use [GitHub color scheme](https://github.com/croaky/vim-colors-github).
 * Use [vim-mkdir](https://github.com/pbrisbin/vim-mkdir) for automatically
   creating non-existing directories before writing the buffer.
 * Use [Vundle](https://github.com/gmarik/Vundle.vim) to manage plugins.

--- a/vimrc
+++ b/vimrc
@@ -74,11 +74,6 @@ if executable('ag')
   let g:ctrlp_use_caching = 0
 endif
 
-" Color scheme
-colorscheme github
-highlight NonText guibg=#060606
-highlight Folded  guibg=#0A0A0A guifg=#9090D0
-
 " Make it obvious where 80 characters is
 set textwidth=80
 set colorcolumn=+1

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -11,7 +11,6 @@ Plugin 'gmarik/Vundle.vim'
 
 " Define bundles via Github repos
 Plugin 'christoomey/vim-run-interactive'
-Plugin 'croaky/vim-colors-github'
 Plugin 'kchmck/vim-coffee-script'
 Plugin 'ctrlpvim/ctrlp.vim'
 Plugin 'pbrisbin/vim-mkdir'


### PR DESCRIPTION
* Every time I pull updates from this repo into my own dotfiles, I have to
  reconfigure my preferred theme (solarized)
* Seems like there is not a majority or plurality of thoughbotters using a
  single colorscheme
* Easiest to just not specify a colorscheme
* See https://forum.upcase.com/t/why-is-the-default-vim-theme-on-dotfiles-is-github/4232