### PR TITLE
Add "bundle search" subcommand

### DIFF
--- a/bin/bundler-search
+++ b/bin/bundler-search
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Search your bundle for the provided pattern
+#   Requires bundler 1.8+ for execution as a bundler subcommand.
+#   Examples:
+#     bundle search Kernal.warn
+#     bundle search current_user clearance
+#     bundle search "Change your password" clearance
+#
+# Arguments:
+#  1. What to search for
+#  2. Which gem names to search (defaults to all gems)
+
+pattern="$1"; shift
+ag "$pattern" $(bundle show --paths "$@")


### PR DESCRIPTION
Bundler 1.8+ added support for git-style subcommands. Any scripts
starting with `bundler-` in your path are executable as bundler
subcommands.

This adds `search` as a subcommand that uses `ag` to search for a string
among all gems in your bundle (default) or optionally a specific gem.
I've found this useful for finding the source of puzzling deprecations,
finding what gem provides a method, and other various things.

This script isn't nearly perfect. It fails confusingly when `bundle show --paths` 
fails (if, for instance, you are not in bundler project). `shellcheck` complains
about quoting but providing the quotes it wants breaks the command. 
But, it works. Pushing this up now to see if others might find it useful and to 
recruit help in making it a bit more robust.