### PR TITLE
Enable autocomplete with dictionary words

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -146,6 +146,9 @@ let g:syntastic_html_tidy_ignore_errors=[" proprietary attribute \"ng-"]
 " Dropbox or kept in Git and managed outside of thoughtbot/dotfiles using rcm.
 set spellfile=$HOME/.vim-spell-en.utf-8.add
 
+" Autocomplete with dictionary words when spell check is on
+set complete+=kspell
+
 " Always use vertical diffs
 set diffopt+=vertical
 


### PR DESCRIPTION
Enable autocomplete with dictionary words when spell check is on

@georgebrock [demonstrated this](https://vimeo.com/122615319) at the Vim London Meetup yesterday. Seems like a useful thing to pull into the thoughtbot dotfiles?