### PR TITLE
Add git alias for hub pr without opening editor

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -18,6 +18,7 @@
   delete-branch = !sh -c 'git push origin :refs/heads/$1 && git branch -D $1' -
   merge-branch = !git checkout master && git merge @{-1}
   pr = !hub pull-request
+  pr-noedit = !GIT_EDITOR=true hub pull-request
   rename-branch = !sh -c 'old=$(git current-branch) && git branch -m $old $1 && git push origin --set-upstream $1 && git push origin --delete $old' -
   st = status
   up = !git fetch origin && git rebase origin/master


### PR DESCRIPTION
* Default behavior of hub when opening a pull-request with only one
  commit is to use the last commit title and body as the title and body
  for the pull-request, but hub opens the editor to allow you to make
  changes to the title and body. Since the commit message should be
  sufficient there is no need to have hub open the editor.
* This alias allows the last commit message to be used but
  prevents hub from opening the editor to make changes.
* Opening a pull-request like this was suggested by the hub developer in this issue https://github.com/github/hub/issues/722