### PR TITLE
Remove 'github' colorscheme from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Your `~/.gitconfig.local` might look like this:
 Your `~/.vimrc.local` might look like this:
 
     " Color scheme
-    colorscheme github
+    colorscheme darkblue
     highlight NonText guibg=#060606
     highlight Folded  guibg=#0A0A0A guifg=#9090D0
 


### PR DESCRIPTION
'github' colorscheme was deleted in b3cb238