### PR TITLE
Exclude `node_modules` and `bower_components`

### DIFF
--- a/agignore
+++ b/agignore
@@ -3,3 +3,5 @@ tags
 tmp
 vendor
 .git/
+bower_components/
+node_modules/


### PR DESCRIPTION
This is equivalent to excluding `vendor/assets` in a Rails project.

JS Dependency trees (especially npm packages) can be extremely noisy.