### PR TITLE
Move Git aliases to subcommand scripts

### DIFF
--- a/bin/git-co-pr
+++ b/bin/git-co-pr
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+git fetch origin "pull/$1/head:pr/$1"
+git checkout "pr/$1"

--- a/bin/git-create-branch
+++ b/bin/git-create-branch
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+git push origin "HEAD:refs/heads/$1"
+git fetch origin
+git branch --track "$1" "origin/$1"
+cd .
+git checkout "$1"

--- a/bin/git-ctags
+++ b/bin/git-ctags
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+[ -f .git/hooks/ctags ] || git init
+.git/hooks/ctags

--- a/bin/git-current-branch
+++ b/bin/git-current-branch
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+git rev-parse --abbrev-ref HEAD

--- a/bin/git-delete-branch
+++ b/bin/git-delete-branch
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+git push origin :refs/heads/"$1"
+git branch --delete "$1"

--- a/bin/git-merge-branch
+++ b/bin/git-merge-branch
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+git checkout master
+git merge "@{-1}"

--- a/bin/git-pr
+++ b/bin/git-pr
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+hub pull-request

--- a/bin/git-rename-branch
+++ b/bin/git-rename-branch
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+old=$(git current-branch)
+git branch -m "$old" "$1"
+git push origin --set-upstream "$1"
+git push origin --delete "$old"

--- a/bin/git-up
+++ b/bin/git-up
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+git fetch origin
+git rebase origin/master "$@"

--- a/gitconfig
+++ b/gitconfig
@@ -11,16 +11,7 @@
   ca = commit --amend -v
   ci = commit -v
   co = checkout
-  co-pr = !sh -c 'git fetch origin pull/$1/head:pr/$1 && git checkout pr/$1' -
-  create-branch = !sh -c 'git push origin HEAD:refs/heads/$1 && git fetch origin && git branch --track $1 origin/$1 && cd . && git checkout $1' -
-  ctags = "!sh -c '[ -f .git/hooks/ctags ] || git init; .git/hooks/ctags' git-ctags"
-  current-branch = !sh -c 'git rev-parse --abbrev-ref HEAD' -
-  delete-branch = !sh -c 'git push origin :refs/heads/$1 && git branch -D $1' -
-  merge-branch = !git checkout master && git merge @{-1}
-  pr = !hub pull-request
-  rename-branch = !sh -c 'old=$(git current-branch) && git branch -m $old $1 && git push origin --set-upstream $1 && git push origin --delete $old' -
   st = status
-  up = !git fetch origin && git rebase origin/master
 [core]
   excludesfile = ~/.gitignore
   autocrlf = input


### PR DESCRIPTION
Any executable script on you PATH
that is named `git-some-name`
will be available as a git subcommand,
which means you could do `git some-name` to run the script.

Git adds them to `git help -a` under the title
"git commands available from elsewhere on your $PATH",
which will then power the auto completion,
so that will also work for any command you add.

http://blog.zamith.pt/blog/2014/11/05/supercharging-your-git/

Examples of other projects that structure their dotfiles like this:

https://github.com/robbyrussell/oh-my-zsh
https://github.com/tj/git-extras
https://github.com/holman/dotfiles