### PR TITLE
Ignore `.env.local` instead of `.env`.

### DIFF
--- a/gitignore
+++ b/gitignore
@@ -1,7 +1,7 @@
 .DS_Store
 *.sw[nop]
 .bundle
-.env
+.env.local
 db/*.sqlite3
 log/*.log
 rerun.txt


### PR DESCRIPTION
Here is an common occurrence that the current `.gitignore` supports:

1. The `.sample.env` (or like) file is updated with environment variables after a feature is merged.
2. A developer pulls the latest from master and runs the test suite.
3. It fails with an opaque error message.

A more robust workflow versions keys used in local development in the `.env` file and overrides these locally with the `.env.local` file.

See https://github.com/bkeepers/dotenv#should-i-commit-my-env-file