### PR TITLE
Added git_template/info/exclude for Xcode

### DIFF
--- a/git_template/info/exclude
+++ b/git_template/info/exclude
@@ -1,0 +1,6 @@
+# git ls-files --others --exclude-from=.git/info/exclude
+# Lines that start with '#' are comments.
+# For a project mostly in C, the following would be a good set of
+# exclude patterns (uncomment them if you want to use them):
+# *.[oa]
+# *~


### PR DESCRIPTION
Xcode >=6.0.1 throws an error when creating a new git-tracked project without an 'exclude' file. Created the exclude file to correspond to the existing gitignore file.