### PR TITLE
Remove ctags.vim plugin

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -41,7 +41,6 @@ Plug 'tpope/vim-rails'
 Plug 'tpope/vim-repeat'
 Plug 'tpope/vim-surround'
 Plug 'vim-ruby/vim-ruby'
-Plug 'vim-scripts/ctags.vim'
 Plug 'vim-scripts/tComment'
 
 if filereadable(expand("~/.vimrc.bundles.local"))


### PR DESCRIPTION
The plugin seems abandoned and doesn't work with our setup as it is.