### PR TITLE
Enable Git's autosquash feature by default.

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -21,5 +21,7 @@
   template = ~/.gitmessage
 [fetch]
   prune = true
+[rebase]
+  autosquash = true
 [include]
   path = ~/.gitconfig.local


### PR DESCRIPTION
Autosquash makes it quicker and easier to squash or fixup commits during an interactive rebase. It can be enabled for each rebase using `git rebase -i --autosquash`, but it's easier to turn it on by default.

Say I have this history:

    $ git log --oneline
    aaa1111 A first commit
    bbb2222 A second commit
    ccc3333 A third commit

I make another change that I already know should be squashed into "A second commit". I can do this:

    $ git add .
    $ git commit --squash bbb2222
    [my-branch ddd4444] squash! A second commit

Then when I rebase:

    $ git rebase -i origin/my-branch

The interactive rebase list will be set up ready to squash:

    pick aaa1111 A first commit
    pick bbb2222 A second commit
    squash ddd4444 squash! A second commit
    pick ccc3333 A third commit

Since it's unlikely that anyone will be writing a commit message that begins `squash!` or `fixup!` when they don't want this behaviour, and the user still has a chance to review what's going to happen with the rebase, it's safe to have it always turned on.