### PR TITLE
Remove matchit.zip plugin

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -42,7 +42,6 @@ Plug 'tpope/vim-repeat'
 Plug 'tpope/vim-surround'
 Plug 'vim-ruby/vim-ruby'
 Plug 'vim-scripts/ctags.vim'
-Plug 'vim-scripts/matchit.zip'
 Plug 'vim-scripts/tComment'
 
 if filereadable(expand("~/.vimrc.bundles.local"))


### PR DESCRIPTION
* This plugin is no longer maintained and is included in vim by default.
* Per the docs at https://github.com/vim-scripts/matchit.zip
  Since vim 6.0, matchit.vim has been included in the standard vim distribution,
  under the macros/ directory; the version here may be more recent.
* The version included in the vim macros directory is the same version
  being added in the vimrc.bundles file from github version 1.13.2