### PR TITLE
Source matchit.vim from vim/macros directory

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -22,6 +22,11 @@ if filereadable(expand("~/.vimrc.bundles"))
   source ~/.vimrc.bundles
 endif
 
+" Load matchit.vim, but only if the user hasn't installed a newer version.
+if !exists('g:loaded_matchit') && findfile('plugin/matchit.vim', &rtp) ==# ''
+  runtime! macros/matchit.vim
+endif
+
 filetype plugin indent on
 
 augroup vimrcEx


### PR DESCRIPTION
* After removing the matchit.vim plugin from the vimrc.bundles file in
  this pull request https://github.com/thoughtbot/dotfiles/pull/379. It
  was brought to my attention that plugins in the macros directory are
  not automatically loaded due to backwards compatibility issues.
* Add entry to vimrc to source the matchit.vim plugin from the macros
  directory, if the user does not have it installed already. This is how
  Tim Pope adds the matchit.vim plugin to vimrc in his vim-sensible plugin.
  https://github.com/tpope/vim-sensible/blob/master/plugin/sensible.vim#L88