### PR TITLE
Add "^K" keybind

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -51,6 +51,7 @@ bindkey jj vi-cmd-mode
 # handy keybindings
 bindkey "^A" beginning-of-line
 bindkey "^E" end-of-line
+bindkey "^K" kill-line
 bindkey "^R" history-incremental-search-backward
 bindkey "^P" history-search-backward
 bindkey "^Y" accept-and-hold


### PR DESCRIPTION
I'm used to running `^A^K` to delete the current line no matter where I am, but this isn't working using these dotfiles (instead, a `^K` is prepended to the line).

So far I've added this keybinding to `zshrc.local`, but maybe somebody else will find it useful.

NB: the sequence `^E^U` accomplishes the same thing and it's currently working.
