### PR TITLE
Use C-s as tmux prefix

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -10,9 +10,7 @@ bind l select-pane -R
 bind-key -r C-h select-window -t :-
 bind-key -r C-l select-window -t :+
 
-# act like GNU screen
-unbind C-b
-set -g prefix C-a
+set -g prefix2 C-s
 
 # start window numbers at 1 to match keyboard order with tmux window order
 set -g base-index 1
@@ -32,8 +30,10 @@ set -g status-right ''
 # increase scrollback lines
 set -g history-limit 10000
 
-# switch to last pane
-bind-key C-a last-pane
+# prefix -> back-one-character
+bind-key C-b send-prefix
+# prefix-2 -> forward-incremental-history-search
+bind-key C-s send-prefix -2
 
 # Local config
 if-shell "[ -f ~/.tmux.conf.local ]" 'source ~/.tmux.conf.local'


### PR DESCRIPTION
C-a allow use to trigger tmux prefix more easily than C-b, at the cost
of overriding the readline beginning of line. This change remaps it to
C-s, which has the same effect without that drawback.