### PR TITLE
Add third-party site-functions to $fpath

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -9,7 +9,7 @@ setopt promptsubst
 export PS1='${SSH_CONNECTION+"%{$fg_bold[green]%}%n@%m:"}%{$fg_bold[blue]%}%c%{$reset_color%}$(git_prompt_info) %# '
 
 # load our own completion functions
-fpath=(~/.zsh/completion $fpath)
+fpath=(~/.zsh/completion /usr/local/share/zsh/site-functions $fpath)
 
 # completion
 autoload -U compinit


### PR DESCRIPTION
Third-party completions get added to
`/usr/local/share/zsh/site-functions`.

Standard `$fpath` contains `/usr/share/zsh/site-functions`
(not the missing `local`).

By adding this to the `$fpath` git subcommands get completed correctly.
Related to https://github.com/thoughtbot/dotfiles/pull/373.