### PR TITLE
Save file before running tests via vim-rspec

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -118,8 +118,8 @@ nnoremap <Up> :echoe "Use k"<CR>
 nnoremap <Down> :echoe "Use j"<CR>
 
 " vim-rspec mappings
-nnoremap <Leader>t :call RunCurrentSpecFile()<CR>
-nnoremap <Leader>s :call RunNearestSpec()<CR>
+nnoremap <Leader>t :w<CR>:call RunCurrentSpecFile()<CR>
+nnoremap <Leader>s :w<CR>:call RunNearestSpec()<CR>
 nnoremap <Leader>l :call RunLastSpec()<CR>
 
 " Run commands that require an interactive shell


### PR DESCRIPTION
* Reduces the number of keystrokes to run a test
* Prevents the mistake of forgetting to save the spec file after editing it