### PR TITLE
git: Ignore `.agignore` in `.gitignore`

### DIFF
--- a/gitignore
+++ b/gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 *.sw[nop]
+.agignore
 .bundle
 .env
 db/*.sqlite3


### PR DESCRIPTION
This excludes project-level `.agignore` files from git.