### PR TITLE
Add `ctags` support for various Ruby DSLs

### DIFF
--- a/ctags
+++ b/ctags
@@ -1,0 +1,2 @@
+--regex-ruby=/(^|[:;])[ \t]*([A-Z][[:alnum:]_]+) *=/\2/c,class,constant/
+--regex-ruby=/^[ \t]*attr_(reader|writer|accessor) (:[a-z0-9_]+, )*:([a-z0-9_]+)/\3/A,attr/


### PR DESCRIPTION
I gave a lightning talk today about `ctags` and how I use it and showed
of some niceties I have configured. I thought I could share it with the
rest of the users of our dotfiles.

This adds support for:
- `attr_{reader,writer,accessor)`
- RSpec spec dsl:
  - context
  - describe
  - feature
  - it
  - scenario
  - shared_examples