### PR TITLE
Ignore "useless use of variable in void context"

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -141,6 +141,8 @@ nnoremap <C-l> <C-w>l
 " configure syntastic syntax checking to check on open as well as save
 let g:syntastic_check_on_open=1
 let g:syntastic_html_tidy_ignore_errors=[" proprietary attribute \"ng-"]
+let g:syntastic_eruby_ruby_quiet_messages =
+    \ {"regex": "possibly useless use of a variable in void context"}
 
 " Set spellfile to location that is guaranteed to exist, can be symlinked to
 " Dropbox or kept in Git and managed outside of thoughtbot/dotfiles using rcm.


### PR DESCRIPTION
The following ERB generates a "Possibly useless use of variable in void
context" warning from Syntastic:

```erb
<%= comment %>
```

The warning can be eliminated by making it:

```erb
<%= comment.to_s %>
```

However, this behavior is the default and is redundant. There are other
cases where this warning pops up and in each case I've found it to be of
no use.