### PR TITLE
Remove note about ctrl-a in tmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,6 @@ configuration:
 
 * Improve color resolution.
 * Remove administrative debris (session name, hostname, time) in status bar.
-* Set prefix to `Ctrl+a` (like GNU screen).
 * Soften status bar color from harsh green to light gray.
 
 [git](http://git-scm.com/) configuration:


### PR DESCRIPTION
Since it doesn't work like that anymore.

I wonder was it changed intentionally (it didn't use to be so a year ago) or by accident?