### PR TITLE
Make Git message template more actionable

### DIFF
--- a/gitmessage
+++ b/gitmessage
@@ -1,20 +1,15 @@
 # 50-character subject line
 
-# 72-character wrapped description.
+Why:
 
-Why this is necessary:
-
-*
 *
 
 How it addresses the need:
 
 *
-*
 
 Side effects:
 
-*
 *
 
 # Link to the ticket, if any.

--- a/gitmessage
+++ b/gitmessage
@@ -1,4 +1,4 @@
-# 50-character subject line
+
 
 Why:
 

--- a/gitmessage
+++ b/gitmessage
@@ -1,11 +1,20 @@
-
-
 # 50-character subject line
-#
-# 72-character wrapped longer description. This should answer:
-#
-# * Why was this change necessary?
-# * How does it address the problem?
-# * Are there any side effects?
-#
-# Include a link to the ticket, if any.
+
+# 72-character wrapped description.
+
+Why this is necessary:
+
+*
+*
+
+How it addresses the need:
+
+*
+*
+
+Side effects:
+
+*
+*
+
+# Link to the ticket, if any.

--- a/gitmessage
+++ b/gitmessage
@@ -4,12 +4,4 @@ Why:
 
 *
 
-How it addresses the need:
-
-*
-
-Side effects:
-
-*
-
 # Link to the ticket, if any.


### PR DESCRIPTION
Why this is necessary:

* All-commented template is easy to ignore/blends into Git default
  "Please enter the commit message for your changes..."
* Deleting the commented questions results in a pull request description
  that could blend the "why", "how", and "side effects" for reviewers.

How it addresses the need:

* Expose "why", "how", and "side effects" to pull request reviewers
  in a more consistent, separated, easy-to-read manner.
* Eliminates whitespace at top of commit message edit view so the person
  is more likely to "fill in the blanks" of the template structure
  rather than free-form their description at the top.

Side effects:

* None.