### PR TITLE
Add quotes for variables in replace

### DIFF
--- a/bin/replace
+++ b/bin/replace
@@ -4,9 +4,9 @@
 #
 # replace foo bar **/*.rb
 
-find_this=$1
+find_this="$1"
 shift
-replace_with=$1
+replace_with="$1"
 shift
 
-ag -l --nocolor $find_this $* | xargs sed -i '' "s/$find_this/$replace_with/g"
+ag -l --nocolor "$find_this" $* | xargs sed -i '' "s/$find_this/$replace_with/g"


### PR DESCRIPTION
`bin/replace` has some weird behavior when given arguments with spaces, e.g.:
```
$ bin/replace 'extra files' 'EXTRA FILES' zshrc
ERR: Error stat()ing: files
ERR: Error opening directory files: No such file or directory
```
Double quotes around the variable expressions makes this go away.