### PR TITLE
Provide an example of specifying dotfiles dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Install the dotfiles:
 
     env RCRC=$HOME/dotfiles/rcrc rcup
 
+You can use just `rcup` if you specify your dotfiles directory in `~/.rcrc`.
+[See example]/(https://github.com/thoughtbot/dotfiles/blob/master/rcrc).
+
 This command will create symlinks for config files in your home directory.
 Setting the `RCRC` environment variable tells `rcup` to use standard
 configuration options:


### PR DESCRIPTION
Why:

* There can be confusion on how to tell `rcup` where local dotfiles
  have been installed.