### PR TITLE
Add ^F and ^B readline bindings and modify vi-mode binding.

### DIFF
--- a/zshenv
+++ b/zshenv
@@ -7,7 +7,7 @@ export PATH="$HOME/.bin:/usr/local/sbin:$PATH"
 
 # load rbenv if available
 if which rbenv &>/dev/null ; then
-  eval "$(rbenv init - --no-rehash)"
+  eval "$(rbenv init - zsh --no-rehash)"
 fi
 
 # mkdir .git/safe in the root of repositories you trust

--- a/zshrc
+++ b/zshrc
@@ -45,12 +45,13 @@ unsetopt nomatch
 
 # vi mode
 bindkey -v
-bindkey "^F" vi-cmd-mode
-bindkey jj vi-cmd-mode
+bindkey "^J" vi-cmd-mode
 
 # handy keybindings
 bindkey "^A" beginning-of-line
+bindkey "^B" backward-char
 bindkey "^E" end-of-line
+bindkey "^F" forward-char
 bindkey "^K" kill-line
 bindkey "^R" history-incremental-search-backward
 bindkey "^P" history-search-backward


### PR DESCRIPTION
Most of the bindings for readline are already included in the zsh
configuration except for forward and backward character. For those used
to the full suite, it would be nice include ``^F`` and ``^B`` as well.

The current vi-mode mode binding of jj is troublesome for those who
either have jj in their github username or email address. One of the
most biggest problems is when copying a git repo into the terminal and
having it clipped. For example copying my repo name to git clone yields:

    git@github.com:ngholtz/dotfiles.git

In addition the buffer after typing a j means that I need to wait a
second after typing j or else it will enter vi-mode which can be a bit
annoying.

I propose that the vi-mode key just be ``^J`` to prevent both of those
issues.

Lastly, just a minor change to the rbenv init command to fix issues
where $SHELL is bin/bash causing the following message:

    /completions/rbenv.bash:14: command not found: complete

Fix suggested [here](https://github.com/sstephenson/rbenv/issues/239).