### PR TITLE
Add .nvimrc, source .vimrc

### DIFF
--- a/nvimrc
+++ b/nvimrc
@@ -1,0 +1,5 @@
+source $HOME/.vimrc
+
+if filereadable($HOME . "/.nvimrc.local")
+  source ~/.nvimrc.local
+endif


### PR DESCRIPTION
Using Neovim should be a straightforward transition from Vim. Getting started can be a surprise when `.vimrc` is not sourced, as Neovim looks for an `.nvimrc`. This change sources `.vimrc` by default for Neovim, and allows user-specific Neovim configuration through `.nvimrc.local`.

Users who have an exceptional reason to override this convention and don't want their "classic" `.vimrc` sourced can override by placing a `.nvimrc` file (blank or otherwise) in their local customizations.