### PR TITLE
Change Plugin to Plug

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -21,7 +21,7 @@ function! VundleToPlug(vundle_command, arg, ...)
   Plug a:arg, vim_plug_options
 endfunction
 
-com! -nargs=+  -bar Plugin call VundleToPlug("Plugin", <args>)
+com! -nargs=+  -bar Plugin call VundleToPlug("Plug", <args>)
 com! -nargs=+  -bar Bundle call VundleToPlug("Bundle", <args>)
 
 call plug#begin('~/.vim/bundle')


### PR DESCRIPTION
Should use `Plug` other than `Plugin` to install vim plugs