### PR TITLE
Add custom git command `git ranch`

### DIFF
--- a/bin/git-ranch
+++ b/bin/git-ranch
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+echo "Howdy pardner! Looks like you've mistaken a git command. Did you mean \`git branch\`? See \`git --help\`. Yee-haw!
+
+While yer in the ranchin' mood, why don't ya try this recipe for bacon 'n beans?
+
+Ingredients
+
+1 pound 90% lean ground beef*
+1 pound bacon
+1 medium yellow onion, chopped
+2 (28 ounce) cans baked beans (I used Bush's Original)
+1 (15 ounce) can pork and beans
+2 (15 ounce) cans black beans, drained and rinsed
+1 cup barbecue sauce (I used Sweet Baby Ray's Originial)
+1/4 cup yellow mustard
+2 tablespoons Worcestershire sauce
+
+Instructions
+
+Cook the bacon in a large skillet. You can either chop it beforehand or crumble
+it afterward. Remove to a paper-towel lined plate. Brown the ground beef in a
+the bacon grease. Remove to a large bowl and discard the fat. Preheat the oven
+to 400 degrees F. Sauté the onions until they are translucent, about 5-8
+minutes. In a large bowl, combine ground beef, bacon, onions, baked beans, pork
+and beans, black beans, barbecue sauce, mustard, and Worcestershire sauce. Taste
+it. Add more BBQ sauce if you want. Spread the beans into a 9x13 inch pan. Bake
+at 400 for 30 minutes. Turn the oven down to 350 and cover the beans with foil.
+Bake for another 20-30 minutes. I like mine extra crispy on top, so I broil
+them for a couple minutes, but that's not necessary unless you like slightly
+burned beans. (I mean who doesn't.) Serve hot!
+
+Notes:
+
+*Use 90%, otherwise your beans will end up greasy.
+
+Source: http://thefoodcharlatan.com/2015/05/14/bacon-baked-beans/
+"


### PR DESCRIPTION
Sometimes when typing `git branch` I leave off the leading `b`, leading
to the boring message:

> git: 'ranch' is not a git command. See 'git --help'.

This adds a custom `git ranch` command with a friendlier funny message.