### PR TITLE
Add function for opening project trello boards

### DIFF
--- a/zsh/functions/tbot
+++ b/zsh/functions/tbot
@@ -1,0 +1,3 @@
+tbot () {
+  open "https://tbot.io/$1"
+}

--- a/zsh/functions/trello
+++ b/zsh/functions/trello
@@ -1,0 +1,3 @@
+trello () {
+  tbot "t/$(basename $PWD)"
+}


### PR DESCRIPTION
Also include a script for opening any tbot.io link.

These functions set up a convention for setting up tbot.io links
for project trello boards under `tbot.io/t/project-name`.

The function reads from the current directory name, and tries to open up a
tbot.io link based on that name.

I've been doing this in my dotfiles for a little while,
and it's been great.

If a tbot.io link isn't set up the first time I use it, I link it up and
it works from then on. If everyone starts setting up these links for
their projects, everyone can start benefitting from instant trello
access.

We currently have set up:

- t/administrate
- t/apprentice
- t/blog
- t/feed
- t/formkeep
- t/growth
- t/hound
- t/success
- t/thoughtbot
- t/upcase
- t/upcase-content
- t/upcase-growth
- t/weekly-iteration