### PR TITLE
Allow local binstub overrides

### DIFF
--- a/gitignore
+++ b/gitignore
@@ -9,3 +9,4 @@ tags
 !tags/
 tmp/**/*
 !tmp/cache/.keep
+local_bin/

--- a/zshenv
+++ b/zshenv
@@ -11,7 +11,7 @@ if which rbenv &>/dev/null ; then
 fi
 
 # mkdir .git/safe in the root of repositories you trust
-export PATH=".git/safe/../../bin:$PATH"
+export PATH=".git/safe/../../local_bin:.git/safe/../../bin:$PATH"
 
 # Local config
 [[ -f ~/.zshenv.local ]] && source ~/.zshenv.local


### PR DESCRIPTION
We're now checking in binstubs to each project's `bin` directory and,
optionally, adding that `bin` directory to our path by adding the
`.git/safe` directory.

There are some environments where we need to tweak the behavior of the
binstub locally. For instance, when running docker we don't want to
execute the binstub locally; rather, we want to execute that binstub in
the context of our docker container.

On a current project that uses Docker, I have the following `rails`
binstub in my `local_bin` directory:

```
#!/bin/sh

docker-compose run web rails "$@"
```

By putting this command first in my path, it allows all of my other
rails aliases to work as they would if I were working locally. I have
similar commands for `rspec` and `rake`.