### PR TITLE
Fix $PATH on OS X El Capitan

### DIFF
--- a/zprofile
+++ b/zprofile
@@ -1,0 +1,17 @@
+# ensure dotfiles bin directory is loaded first
+export PATH="$HOME/.bin:/usr/local/sbin:$PATH"
+
+# load rbenv if available
+if which rbenv &>/dev/null ; then
+  eval "$(rbenv init - --no-rehash)"
+fi
+
+# mkdir .git/safe in the root of repositories you trust
+export PATH=".git/safe/../../bin:$PATH"
+
+# Local config
+[[ -f ~/.zprofile.local ]] && source ~/.zprofile.local
+
+# tmux loads zsh as a login shell, which may result in duplicate $PATH entries
+# from ~/.zprofile. This removes duplicates from $PATH.
+typeset -U PATH

--- a/zshenv
+++ b/zshenv
@@ -2,16 +2,5 @@
 export VISUAL=vim
 export EDITOR=$VISUAL
 
-# ensure dotfiles bin directory is loaded first
-export PATH="$HOME/.bin:/usr/local/sbin:$PATH"
-
-# load rbenv if available
-if which rbenv &>/dev/null ; then
-  eval "$(rbenv init - --no-rehash)"
-fi
-
-# mkdir .git/safe in the root of repositories you trust
-export PATH=".git/safe/../../bin:$PATH"
-
 # Local config
 [[ -f ~/.zshenv.local ]] && source ~/.zshenv.local


### PR DESCRIPTION
OS X El Capitan [moved `path_helper`][1] from `/etc/zshenv` to
`/etc/zprofile`. This causes the changes to `$PATH` in `~/.zshenv` to be
overridden/re-ordered.

Moving the `$PATH` modifications to `~/.zprofile` causes them to be
loaded after OS X's `path_helper`, resulting in the expected order.

Per convention, `~/.zprofile` sources an optional `~/.zprofile.local`.

Additionally, because `tmux` loads `zsh` as a login shell, `~/.zprofile`
is sourced twice; this commit adds a command to `~/.zprofile` to remove
the resulting duplicate entries from `$PATH`.

[1]: http://www.zsh.org/mla/users/2015/msg00726.html