### PR TITLE
Add instructions to fix path on OS X El Capitan

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ You can safely run `rcup` multiple times to update:
 You should run `rcup` after pulling a new version of the repository to symlink
 any new files in the repository.
 
+#### Note for OS X El Capitan Users 
+
+OS X El Capitan (10.11) calls `path_helper` from `/etc/zprofile`, which gets 
+sourced *after* `.zshenv`, and will reorder your path in such a way that 
+installed software such as Ruby, rbenv, Homebrew, etc. may not work correctly. 
+You can rename the file to prevent it from editing your environment path after 
+changes made in `.zshenv`:
+
+```shell
+% sudo mv /etc/{zprofile, zshenv}
+```
+
 Make your own customizations
 ----------------------------
 


### PR DESCRIPTION
OS X 10.11 changes the file where `path_helper` is invoked from
`/etc/zshenv` to `/etc/zprofile`. The change results in `path_helper`
rearranging the path in such a way that interferes with path changes
made in `.zshenv`.

This README update instructs users to rename `/etc/zprofile` to
`/etc/zshenv` so that `.zshenv` (and `.zshenv.local`) will be loaded
*after* `path_helper` is called, maintaining the desired precedence of
paths.

Thanks to @reshleman and @ventsislaf for investigating and offering
solutions.