### PR TITLE
Warn users with harmful `path_helper` calls

### DIFF
--- a/hooks/post-up
+++ b/hooks/post-up
@@ -9,7 +9,7 @@ fi
 
 vim -u $HOME/.vimrc.bundles +PlugInstall +PlugClean! +qa
 
-if grep --quiet --no-messages 'path_helper' /etc/zprofile; then
+if grep --quiet --no-messages path_helper /etc/zprofile; then
   cat <<eom
 
 Your system is sourcing the OS X 'path_helper' from /etc/zprofile.

--- a/hooks/post-up
+++ b/hooks/post-up
@@ -6,4 +6,15 @@ if [ ! -e $HOME/.vim/autoload/plug.vim ]; then
   curl -fLo $HOME/.vim/autoload/plug.vim --create-dirs \
       https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 fi
+
 vim -u $HOME/.vimrc.bundles +PlugInstall +PlugClean! +qa
+
+if grep --quiet --silent 'path_helper' /etc/zprofile; then
+  cat <<eom
+
+Your system is sourcing the OS X `path_helper` from /etc/zprofile.
+This will interfere with path ordering. For more information, see:
+https://github.com/thoughtbot/dotfiles#note-for-os-x-el-capitan-users
+
+eom
+fi

--- a/hooks/post-up
+++ b/hooks/post-up
@@ -9,7 +9,7 @@ fi
 
 vim -u $HOME/.vimrc.bundles +PlugInstall +PlugClean! +qa
 
-if grep --quiet --silent 'path_helper' /etc/zprofile; then
+if grep --quiet --no-messages 'path_helper' /etc/zprofile; then
   cat <<eom
 
 Your system is sourcing the OS X 'path_helper' from /etc/zprofile.

--- a/hooks/post-up
+++ b/hooks/post-up
@@ -12,7 +12,7 @@ vim -u $HOME/.vimrc.bundles +PlugInstall +PlugClean! +qa
 if grep --quiet --silent 'path_helper' /etc/zprofile; then
   cat <<eom
 
-Your system is sourcing the OS X `path_helper` from /etc/zprofile.
+Your system is sourcing the OS X 'path_helper' from /etc/zprofile.
 This will interfere with path ordering. For more information, see:
 https://github.com/thoughtbot/dotfiles#note-for-os-x-el-capitan-users
 


### PR DESCRIPTION
El Capitan moves the `path_helper` call to `zprofile`, but our dotfiles
had already accounted for it being in `zshenv` where it was previously.