### PR TITLE
Fix a command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,16 @@ You can safely run `rcup` multiple times to update:
 You should run `rcup` after pulling a new version of the repository to symlink
 any new files in the repository.
 
-#### Note for OS X El Capitan Users 
+#### Note for OS X El Capitan Users
 
-OS X El Capitan (10.11) calls `path_helper` from `/etc/zprofile`, which gets 
-sourced *after* `.zshenv`, and will reorder your path in such a way that 
-installed software such as Ruby, rbenv, Homebrew, etc. may not work correctly. 
-You can rename the file to prevent it from editing your environment path after 
+OS X El Capitan (10.11) calls `path_helper` from `/etc/zprofile`, which gets
+sourced *after* `.zshenv`, and will reorder your path in such a way that
+installed software such as Ruby, rbenv, Homebrew, etc. may not work correctly.
+You can rename the file to prevent it from editing your environment path after
 changes made in `.zshenv`:
 
 ```shell
-% sudo mv /etc/{zprofile, zshenv}
+% sudo mv /etc/{zprofile,zshenv}
 ```
 
 Make your own customizations


### PR DESCRIPTION
The quoted instruction to move `/etc/zprofile` to `/etc/zshenv` has  space between the old and new filenames which breaks in the shell..