### PR TITLE
Use `command -v` instead of `which` in conditionals

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Your `~/.vimrc.local` might look like this:
 Your `~/.zshenv.local` might look like this:
 
     # load pyenv if available
-    if which pyenv &>/dev/null ; then
+    if command -v pyenv &>/dev/null ; then
       eval "$(pyenv init -)"
     fi
 

--- a/zshenv
+++ b/zshenv
@@ -6,7 +6,7 @@ export EDITOR=$VISUAL
 export PATH="$HOME/.bin:/usr/local/sbin:$PATH"
 
 # load rbenv if available
-if which rbenv &>/dev/null ; then
+if command -v rbenv &>/dev/null ; then
   eval "$(rbenv init - --no-rehash)"
 fi
 


### PR DESCRIPTION
Reason: https://stackoverflow.com/questions/592620/check-if-a-program-exists-from-a-bash-script/677212#677212

Primarily avoid using an external process for simple checks like this, and an added side-effect of consistency across OSes.