### PR TITLE
Split zsh configuration into smaller files

### DIFF
--- a/zsh/completion/_g
+++ b/zsh/completion/_g
@@ -1,0 +1,2 @@
+#compdef g
+compdef g=git

--- a/zsh/configs/color.zsh
+++ b/zsh/configs/color.zsh
@@ -1,0 +1,6 @@
+# makes color constants available
+autoload -U colors
+colors
+
+# enable colored output from ls, etc. on FreeBSD-based systems
+export CLICOLOR=1

--- a/zsh/configs/editor.zsh
+++ b/zsh/configs/editor.zsh
@@ -1,0 +1,2 @@
+export VISUAL=vim
+export EDITOR=$VISUAL

--- a/zsh/configs/history.zsh
+++ b/zsh/configs/history.zsh
@@ -1,0 +1,4 @@
+setopt hist_ignore_all_dups inc_append_history
+HISTFILE=~/.zhistory
+HISTSIZE=4096
+SAVEHIST=4096

--- a/zsh/configs/keybindings.zsh
+++ b/zsh/configs/keybindings.zsh
@@ -1,0 +1,13 @@
+# vi mode
+bindkey -v
+bindkey "^F" vi-cmd-mode
+
+# handy keybindings
+bindkey "^A" beginning-of-line
+bindkey "^E" end-of-line
+bindkey "^K" kill-line
+bindkey "^R" history-incremental-search-backward
+bindkey "^P" history-search-backward
+bindkey "^Y" accept-and-hold
+bindkey "^N" insert-last-word
+bindkey -s "^T" "^[Isudo ^[A" # "t" for "toughguy"

--- a/zsh/configs/options.zsh
+++ b/zsh/configs/options.zsh
@@ -1,0 +1,9 @@
+# awesome cd movements from zshkit
+setopt autocd autopushd pushdminus pushdsilent pushdtohome cdablevars
+DIRSTACKSIZE=5
+
+# Enable extended globbing
+setopt extendedglob
+
+# Allow [ or ] whereever you want
+unsetopt nomatch

--- a/zsh/configs/post/completion.zsh
+++ b/zsh/configs/post/completion.zsh
@@ -1,0 +1,6 @@
+# load our own completion functions
+fpath=(~/.zsh/completion /usr/local/share/zsh/site-functions $fpath)
+
+# completion
+autoload -U compinit
+compinit

--- a/zsh/configs/post/path.zsh
+++ b/zsh/configs/post/path.zsh
@@ -1,0 +1,10 @@
+# ensure dotfiles bin directory is loaded first
+export PATH="$HOME/.bin:/usr/local/sbin:$PATH"
+
+# load rbenv if available
+if command -v rbenv >/dev/null; then
+  eval "$(rbenv init - --no-rehash)"
+fi
+
+# mkdir .git/safe in the root of repositories you trust
+export PATH=".git/safe/../../bin:$PATH"

--- a/zsh/configs/prompt.zsh
+++ b/zsh/configs/prompt.zsh
@@ -1,0 +1,9 @@
+# modify the prompt to contain git branch name if applicable
+git_prompt_info() {
+  current_branch=$(git current-branch 2> /dev/null)
+  if [[ -n $current_branch ]]; then
+    echo " %{$fg_bold[green]%}$current_branch%{$reset_color%}"
+  fi
+}
+setopt promptsubst
+export PS1='${SSH_CONNECTION+"%{$fg_bold[green]%}%n@%m:"}%{$fg_bold[blue]%}%c%{$reset_color%}$(git_prompt_info) %# '

--- a/zsh/functions/g
+++ b/zsh/functions/g
@@ -7,6 +7,3 @@ g() {
     git status
   fi
 }
-
-# Complete g like git
-compdef g=git

--- a/zshrc
+++ b/zshrc
@@ -1,79 +1,7 @@
-# use vim as the visual editor
-export VISUAL=vim
-export EDITOR=$VISUAL
-
-# ensure dotfiles bin directory is loaded first
-export PATH="$HOME/.bin:/usr/local/sbin:$PATH"
-
-# load rbenv if available
-if command -v rbenv >/dev/null; then
-  eval "$(rbenv init - --no-rehash)"
-fi
-
-# mkdir .git/safe in the root of repositories you trust
-export PATH=".git/safe/../../bin:$PATH"
-
-# modify the prompt to contain git branch name if applicable
-git_prompt_info() {
-  current_branch=$(git current-branch 2> /dev/null)
-  if [[ -n $current_branch ]]; then
-    echo " %{$fg_bold[green]%}$current_branch%{$reset_color%}"
-  fi
-}
-setopt promptsubst
-export PS1='${SSH_CONNECTION+"%{$fg_bold[green]%}%n@%m:"}%{$fg_bold[blue]%}%c%{$reset_color%}$(git_prompt_info) %# '
-
-# load our own completion functions
-fpath=(~/.zsh/completion /usr/local/share/zsh/site-functions $fpath)
-
-# completion
-autoload -U compinit
-compinit
-
 # load custom executable functions
 for function in ~/.zsh/functions/*; do
   source $function
 done
-
-# makes color constants available
-autoload -U colors
-colors
-
-# enable colored output from ls, etc
-export CLICOLOR=1
-
-# history settings
-setopt hist_ignore_all_dups inc_append_history
-HISTFILE=~/.zhistory
-HISTSIZE=4096
-SAVEHIST=4096
-
-# awesome cd movements from zshkit
-setopt autocd autopushd pushdminus pushdsilent pushdtohome cdablevars
-DIRSTACKSIZE=5
-
-# Enable extended globbing
-setopt extendedglob
-
-# Allow [ or ] whereever you want
-unsetopt nomatch
-
-# vi mode
-bindkey -v
-bindkey "^F" vi-cmd-mode
-
-# handy keybindings
-bindkey "^A" beginning-of-line
-bindkey "^E" end-of-line
-bindkey "^K" kill-line
-bindkey "^R" history-incremental-search-backward
-bindkey "^P" history-search-backward
-bindkey "^Y" accept-and-hold
-bindkey "^N" insert-last-word
-bindkey -s "^T" "^[Isudo ^[A" # "t" for "toughguy"
-
-# aliases
-[[ -f ~/.aliases ]] && source ~/.aliases
 
 # extra files in ~/.zsh/configs/pre , ~/.zsh/configs , and ~/.zsh/configs/post
 # these are loaded first, second, and third, respectively.
@@ -110,6 +38,9 @@ _load_settings() {
   fi
 }
 _load_settings "$HOME/.zsh/configs"
+
+# aliases
+[[ -f ~/.aliases ]] && source ~/.aliases
 
 # Local config
 [[ -f ~/.zshrc.local ]] && source ~/.zshrc.local


### PR DESCRIPTION
This allows people to incorporate the thoughtbot dotfiles into their own
dotfiles in a more fine-grained manner.

I left some things in zshrc that we should eventually handle more
precisely:

- Load `.zsh/functions/*`. This could instead be replaced with: `mv
  .zsh/functions/* .zsh/configs`.
- Load `.aliases`. This could instead be replaced with: `mv .aliases
  .zsh/configs/aliases.zsh`.
- Load `.zshrc.local`. This file can realistically go away entirely,
  with people adding their own files to `.zsh/configs`.

A further refactoring, which I have done locally, is to introduce a
`~/.sh/configs` directory, in which people can put POSIX-specific
configuration that can be shared between GNU Bash, zsh, ksh, etc:
aliases, functions, paths, prompts, and so on. But one step at a time.