### PR TITLE
Remove zsh `jj` keybinding

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -46,7 +46,6 @@ unsetopt nomatch
 # vi mode
 bindkey -v
 bindkey "^F" vi-cmd-mode
-bindkey jj vi-cmd-mode
 
 # handy keybindings
 bindkey "^A" beginning-of-line


### PR DESCRIPTION
As reported in #405, the `jj` keybinding is problematic for some users
as it enters vi-mode whenever a user types a string that actually
contains two consecutive `j`s.

While consecutive `j`s are unusual in English, usernames with
consecutive `j`s such as that of the contributor who reported the
problem (@jjlangholtz) are common enough that we shouldn't force this
mapping on users.

Users can add their own keybinding to their local configuration or use
the already-provided `Esc` binding to enter vi-mode.

PR #405 contains other keybinding changes that we don't want to apply,
this commit addresses only the `jj` binding.