### PR TITLE
Allow autoloading of proprietary binfiles

### DIFF
--- a/zshenv
+++ b/zshenv
@@ -27,3 +27,16 @@ MSG
 fi
 
 unset _old_path
+
+# load proprietary scripts into path
+if [ -d "$HOME/.proprietary" ]; then
+  # add all sudirectories containing a directory named 'bin' to PATH
+  # EXAMPLE: '~/.proprietary/derp/bin' and '~/.proprietary/bin' would be added,
+  #          but '~/.proprietary/foo/bar/bin' would not.
+  PATH="$(find -L $HOME/.proprietary -maxdepth 2 -mindepth 1 -name 'bin' -type d | tr '\n' ':')$PATH"
+fi
+
+# load rbenv if available
+if command -v rbenv &>/dev/null ; then
+  eval "$(rbenv init - --no-rehash)"
+fi

--- a/zshenv
+++ b/zshenv
@@ -28,20 +28,4 @@ fi
 
 unset _old_path
 
-# load proprietary scripts into path
-if [ -d "$HOME/.proprietary" ]; then
-  # add all sudirectories containing a directory named 'bin' to PATH
-  # EXAMPLE: '~/.proprietary/derp/bin' and '~/.proprietary/bin' would be added,
-  #          but '~/.proprietary/foo/bar/bin' would not.
-  PATH="$(find -L $HOME/.proprietary -maxdepth 2 -mindepth 1 -name 'bin' -type d | tr '\n' ':')$PATH"
-fi
-
-# load rbenv if available
-if command -v rbenv &>/dev/null ; then
-  eval "$(rbenv init - --no-rehash)"
-fi
-
-# mkdir .git/safe in the root of repositories you trust
-PATH=".git/safe/../../bin:$PATH"
-
 export PATH

--- a/zshenv
+++ b/zshenv
@@ -40,3 +40,8 @@ fi
 if command -v rbenv &>/dev/null ; then
   eval "$(rbenv init - --no-rehash)"
 fi
+
+# mkdir .git/safe in the root of repositories you trust
+PATH=".git/safe/../../bin:$PATH"
+
+export PATH

--- a/zshrc
+++ b/zshrc
@@ -3,7 +3,7 @@ export VISUAL=vim
 export EDITOR=$VISUAL
 
 # ensure dotfiles bin directory is loaded first
-export PATH="$HOME/.bin:/usr/local/sbin:$PATH"
+PATH="$HOME/.bin:/usr/local/sbin:$PATH"
 
 # load rbenv if available
 if command -v rbenv >/dev/null; then
@@ -11,7 +11,15 @@ if command -v rbenv >/dev/null; then
 fi
 
 # mkdir .git/safe in the root of repositories you trust
-export PATH=".git/safe/../../bin:$PATH"
+PATH=".git/safe/../../bin:$PATH"
+
+# load proprietary scripts into path
+if [ -d "$HOME/.proprietary" ]; then
+  # add all sudirectories containing a directory named 'bin' to PATH
+  # EXAMPLE: '~/.proprietary/derp/bin' and '~/.proprietary/bin' would be added,
+  #          but '~/.proprietary/foo/bar/bin' would not.
+  PATH="$(find -L $HOME/.proprietary -maxdepth 2 -mindepth 1 -name 'bin' -type d | tr '\n' ':')$PATH"
+fi
 
 # modify the prompt to contain git branch name if applicable
 git_prompt_info() {
@@ -113,3 +121,5 @@ _load_settings "$HOME/.zsh/configs"
 
 # Local config
 [[ -f ~/.zshrc.local ]] && source ~/.zshrc.local
+
+export PATH


### PR DESCRIPTION
Sometimes proprietary scripts specific to server administration are required, but don't fit in the same repository as the rest of the source code. This adds all subdirectories of `~/.proprietary` that contain a directory called "bin" to your path automatically, allowing specific projects' proprietary scripts to be split up into separate directories. Example is in a comment in the code.

Side effects are that the project-specific bin files are included globally. Eventually it would be nice to include based on current working directory, but that borders on [`direnv`](https://github.com/direnv/direnv)'s territory.