### PR TITLE
Allow project-specific vimrc

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -158,3 +158,9 @@ set diffopt+=vertical
 if filereadable($HOME . "/.vimrc.local")
   source ~/.vimrc.local
 endif
+
+" Safely allow project-specific vimrc (check for `.git/safe`)
+if isdirectory(getcwd() . ".git/safe")
+  set secure
+  set exrc
+endif


### PR DESCRIPTION
@croaky made this change in one of our projects to allow spelling to be
conditionally turned on in a text-heavy project.

The setting is turned on after all other configuration is loaded,
including plugins, and `secure` is set so that a project-level `vimrc`
cannot run unsafe commands.