### PR TITLE
Bring shell config into (better) shellcheck compliance

### DIFF
--- a/bin/git-ca
+++ b/bin/git-ca
@@ -1,1 +1,3 @@
-git commit --amend -v --date=$(date +%Y-%m-%dT%H:%M:%S)
+#!/bin/sh
+
+git commit --amend -v --date="$(date +%Y-%m-%dT%H:%M:%S)"

--- a/bin/replace
+++ b/bin/replace
@@ -9,4 +9,4 @@ shift
 replace_with="$1"
 shift
 
-ag -l --nocolor "$find_this" $* | xargs sed -i '' "s/$find_this/$replace_with/g"
+ag -l --nocolor "$find_this" "$@" | xargs sed -i '' "s/$find_this/$replace_with/g"

--- a/git_template/hooks/ctags
+++ b/git_template/hooks/ctags
@@ -3,7 +3,7 @@
 set -e
 
 PATH="/usr/local/bin:$PATH"
-dir="`git rev-parse --git-dir`"
+dir="$(git rev-parse --git-dir)"
 trap 'rm -f "$dir/$$.tags"' EXIT
 git ls-files | \
   "${CTAGS:-ctags}" --tag-relative -L - -f"$dir/$$.tags" --languages=-javascript,sql

--- a/hooks/post-up
+++ b/hooks/post-up
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-touch $HOME/.psqlrc.local
+touch "$HOME"/.psqlrc.local
 
-if [ ! -e $HOME/.vim/autoload/plug.vim ]; then
-  curl -fLo $HOME/.vim/autoload/plug.vim --create-dirs \
+if [ ! -e "$HOME"/.vim/autoload/plug.vim ]; then
+  curl -fLo "$HOME"/.vim/autoload/plug.vim --create-dirs \
       https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 fi
-vim -u $HOME/.vimrc.bundles +PlugInstall +PlugClean! +qa
+vim -u "$HOME"/.vimrc.bundles +PlugInstall +PlugClean! +qa
 
 # detect old OS X broken /etc/zshenv and suggest rename
 if grep -qw path_helper /etc/zshenv 2>/dev/null; then

--- a/zsh/completion/_rspec
+++ b/zsh/completion/_rspec
@@ -1,3 +1,3 @@
 #compdef rspec
 
-compadd -P spec/ `ls spec/**/*_spec.rb | sed -E "s/spec\///g"`
+compadd -P spec/ $(ls spec/**/*_spec.rb | sed -E "s/spec\///g")

--- a/zsh/functions/envup
+++ b/zsh/functions/envup
@@ -2,7 +2,7 @@
 
 function envup() {
   if [ -f .env ]; then
-    export `cat .env`
+    export $(cat .env)
   else
     echo 'No .env file found' 1>&2
     return 1

--- a/zsh/functions/g
+++ b/zsh/functions/g
@@ -1,8 +1,8 @@
 # No arguments: `git status`
 # With arguments: acts like `git`
 g() {
-  if [[ $# > 0 ]]; then
-    git $@
+  if [[ $# -gt 0 ]]; then
+    git "$@"
   else
     git status
   fi


### PR DESCRIPTION
While evaluating linting and testing options for our shell
configuration, a run of Shellcheck against our executables turned up
some places where we could use more consistent syntax across our
executables, such as always using a shebang or quoting `$HOME` when we
build up a larger directory.