### PR TITLE
Update Bundler completion to include new subcommands

### DIFF
--- a/zsh/completion/_bundler
+++ b/zsh/completion/_bundler
@@ -20,16 +20,20 @@ case $state in
       "show[Show the source location of a particular gem in the bundle]" \
       "console[Start an IRB session in the context of the current bundle]" \
       "open[Open an installed gem in the editor]" \
+      "lock[Generate a lockfile for your dependencies]" \
       "viz[Generate a visual representation of your dependencies]" \
       "init[Generate a simple Gemfile, placed in the current directory]" \
       "gem[Create a simple gem, suitable for development with bundler]" \
-      "help[Describe available tasks or one specific task]"
+      "help[Describe available tasks or one specific task]" \
+      "platform[Displays platform compatibility information]" \
+      "outdated[Show all of the outdated gems in the current bundle]" \
+      "clean[Cleans up unused gems in your bundler directory]"
     ret=0
     ;;
   args)
     case $line[1] in
       help)
-        _values 'commands' 'install update package exec config check list show console open viz init gem help' && ret=0
+        _values 'commands' 'install' 'update' 'package' 'exec' 'config' 'check' 'list' 'show' 'console' 'open' 'lock' 'viz' 'init' 'gem' 'help' 'platform' 'outdated' 'clean' && ret=0
         ;;
       install)
         _arguments \
@@ -66,4 +70,3 @@ case $state in
 esac
 
 return ret
-


### PR DESCRIPTION
The zsh-completions repository has some additional Bundler subcommands
in their completion since we first implemented it a couple years ago.
This change updates our `_bundle` autocompletion definition to include
the subcommands `outdated` and `platform`, as well as separating values
for `bundle help`.

Also:
Separating the individual commands when defining candidates for `bundle
help` allows tab-completion of those subcommands (e.g. hitting `<TAB>`
with `bundle help in` would suggest `init` and `install` and tab
complete either option.