### PR TITLE
PATH cleanup in zshrc

### DIFF
--- a/zsh/functions/move_to_front_of_path
+++ b/zsh/functions/move_to_front_of_path
@@ -1,0 +1,10 @@
+# Reorders existing entry in PATH to have it at the front
+#
+#   move_to_front_of_path "$HOME/.bin"
+#
+move_to_front_of_path() {
+  if [[ ":$PATH:" == *":$1:"* ]]; then
+    PATH=$(echo $PATH | sed 's#'$1'##g' | sed s/:://g | sed s/:$//g | sed s/^://g)
+    PATH="$1${PATH:+":$PATH"}"
+  fi
+}

--- a/zshrc
+++ b/zshrc
@@ -3,7 +3,7 @@ export VISUAL=vim
 export EDITOR=$VISUAL
 
 # ensure dotfiles bin directory is loaded first
-export PATH="$HOME/.bin:/usr/local/sbin:$PATH"
+path=($HOME/.bin /usr/local/sbin $path)
 
 # load rbenv if available
 if command -v rbenv >/dev/null; then
@@ -113,3 +113,16 @@ _load_settings "$HOME/.zsh/configs"
 
 # Local config
 [[ -f ~/.zshrc.local ]] && source ~/.zshrc.local
+
+# mkdir .git/safe in the root of repositories you trust
+path=(.git/safe/../../bin $path)
+
+# readjust order of PATH entries
+move_to_front_of_path "$HOME/.bin"
+move_to_front_of_path ".git/safe/../../bin"
+
+# Remove dupes from PATH
+typeset -U path
+
+# Solidify PATH changes for the rest of the shell sessions
+export PATH


### PR DESCRIPTION
There has been an explosion in my `$PATH` whenever I open a new tab in tmux, specifically with duplicate path entries.

```
# Before:
echo $PATH
# => "/Users/alexanderdav/.proprietary/cape-deploy/bin:/Users/alexanderdav/.proprietary/cape-development/bin:/Users/alexanderdav/.proprietary/cape-ops/bin:/Users/alexanderdav/.proprietary/svn/bin::.git/safe/../../bin:/Users/alexanderdav/.rbenv/shims:/Users/alexanderdav/.bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin:/Users/alexanderdav/.tmuxifier/libexec:.git/safe/../../bin:/Users/alexanderdav/.rbenv/shims:/Users/alexanderdav/.proprietary/cape/bin:/Users/alexanderdav/.rbenv/bin:/Users/alexanderdav/.tmuxifier/bin:/Users/alexanderdav/.bin:/usr/local/sbin"

# After:
echo $PATH
# => "/Users/alexanderdav/.proprietary/cape-deploy/bin:/Users/alexanderdav/.proprietary/cape-development/bin:/Users/alexanderdav/.proprietary/cape-ops/bin:/Users/alexanderdav/.proprietary/svn/bin:.git/safe/../../bin:/Users/alexanderdav/.rbenv/shims:/Users/alexanderdav/.bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin:/Users/alexanderdav/.tmuxifier/libexec:/Users/alexanderdav/.proprietary/cape/bin:/Users/alexanderdav/.rbenv/bin:/Users/alexanderdav/.tmuxifier/bin"
```

See commit messages for specific changes, but overall this does the following:

- PATH helper functions (for use within config files, primarily)
- Removing duplicate PATH entries
- Cleaning up empty entries in PATH