### PR TITLE
Ignore `.env.local` instead of `.env`.

### DIFF
--- a/gitignore
+++ b/gitignore
@@ -1,7 +1,7 @@
 .DS_Store
 *.sw[nop]
 .bundle
-.env
+.env.local
 db/*.sqlite3
 log/*.log
 rerun.txt


### PR DESCRIPTION
It makes sense to version keys used in local development in the `.env`
file, rather than constantly copying them from `.sample.env`.  You can
still override these locally with the `.env.local` file.

- Removes `.env` from the `gitignore` file.
- Adds `.env.local` to the `gitignore` file.

See:

* https://github.com/bkeepers/dotenv#should-i-commit-my-env-file
* https://github.com/thoughtbot/dotfiles/pull/369
* https://github.com/thoughtbot/suspenders/pull/563