### PR TITLE
Recognize JS Linter configuration files as JSON

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -43,6 +43,7 @@ augroup vimrcEx
   " Set syntax highlighting for specific file types
   autocmd BufRead,BufNewFile Appraisals set filetype=ruby
   autocmd BufRead,BufNewFile *.md set filetype=markdown
+  autocmd BufRead,BufNewFile .{jscs,jshint,eslint}rc set filetype=json
 
   " Enable spellchecking for Markdown
   autocmd FileType markdown setlocal spell


### PR DESCRIPTION
Unfortunately, the convention for most JavaScript linters is to name
their configuration `.${TOOL}rc`.

In spite of this name, the configuration files are `JSON`. Forcing vim
to recognize them as JSON would enable syntax highlighting and linting
plugins (like syntastic) to recognize invalidly structured JSON.