### PR TITLE
Add custom ruby installation function

### DIFF
--- a/bin/rinstall
+++ b/bin/rinstall
@@ -1,0 +1,11 @@
+!#/bin/sh
+
+if command -v ruby-install >/dev/null; then
+  ruby-install --install-dir "$(rbenv root)/versions/$1" ruby "$1" && \
+    gem install bundler --conservative
+
+  [ -f Gemfile ] && bundle
+else
+  echo "You need to install ruby-install first."
+  return 1
+fi

--- a/zsh/completion/_rinstall
+++ b/zsh/completion/_rinstall
@@ -1,0 +1,5 @@
+#compdef rinstall
+
+if command -v rbenv >/dev/null; then
+  compadd $(rbenv completions install)
+fi

--- a/zsh/functions/rinstall
+++ b/zsh/functions/rinstall
@@ -1,5 +1,0 @@
-function rinstall () {
-  ruby-install --install-dir "$HOME/.rbenv/versions/$1" ruby "$1"
-  gem install bundler --conservative
-  bundle
-}

--- a/zsh/functions/rinstall
+++ b/zsh/functions/rinstall
@@ -1,0 +1,5 @@
+function rinstall () {
+  ruby-install --install-dir "$HOME/.rbenv/versions/$1" ruby "$1"
+  gem install bundler --conservative
+  bundle
+}


### PR DESCRIPTION
Based on discussion at https://trello.com/c/0rlBCEms/411-ruby-install
Co-dependent on https://github.com/thoughtbot/laptop/pull/419

## Problem:

The two main tools for installing ruby, `ruby-build` and `ruby-install`,
both have drawbacks.

- `ruby-build` requires an update in order to install new versions of
  ruby.
- `ruby-install` requires command-line arguments in order to install
  rubies in an rbenv-compatible way.

## Solution:

Add a wrapper around `ruby-install` that takes care of the command line
arguments for us. This lets us install new ruby versions with the
command:

```
rinstall 2.2.2
```

where 2.2.2 is the version number.

The tool never needs to be updated, and installs into the directory that
rbenv expects. As a bonus, it will automatically install bundler for you
and attempt to `bundle install` for the current directory.