### PR TITLE
Don't export unneeded variables

### DIFF
--- a/zsh/configs/post/path.zsh
+++ b/zsh/configs/post/path.zsh
@@ -1,5 +1,5 @@
 # ensure dotfiles bin directory is loaded first
-export PATH="$HOME/.bin:/usr/local/sbin:$PATH"
+PATH="$HOME/.bin:/usr/local/sbin:$PATH"
 
 # load rbenv if available
 if command -v rbenv >/dev/null; then
@@ -7,4 +7,4 @@ if command -v rbenv >/dev/null; then
 fi
 
 # mkdir .git/safe in the root of repositories you trust
-export PATH=".git/safe/../../bin:$PATH"
+PATH=".git/safe/../../bin:$PATH"

--- a/zsh/configs/prompt.zsh
+++ b/zsh/configs/prompt.zsh
@@ -6,4 +6,4 @@ git_prompt_info() {
   fi
 }
 setopt promptsubst
-export PS1='${SSH_CONNECTION+"%{$fg_bold[green]%}%n@%m:"}%{$fg_bold[blue]%}%c%{$reset_color%}$(git_prompt_info) %# '
+PS1='${SSH_CONNECTION+"%{$fg_bold[green]%}%n@%m:"}%{$fg_bold[blue]%}%c%{$reset_color%}$(git_prompt_info) %# '


### PR DESCRIPTION
`PS1` and `PATH` don't need to be exported in order to perform their
duties in the shell. `PS1` in particular causes breakage if subshells
are launched that don't have access to our `git_prompt_info` function.

Note that `PATH` continues to get `exported` due to `rbenv`'s `init`
subcommand exporting the variable.

Fix #270.