### PR TITLE
Fix tab-completion on `g` function

### DIFF
--- a/zsh/configs/post/completion.zsh
+++ b/zsh/configs/post/completion.zsh
@@ -1,6 +1,0 @@
-# load our own completion functions
-fpath=(~/.zsh/completion /usr/local/share/zsh/site-functions $fpath)
-
-# completion
-autoload -U compinit
-compinit

--- a/zshrc
+++ b/zshrc
@@ -44,3 +44,9 @@ _load_settings "$HOME/.zsh/configs"
 
 # Local config
 [[ -f ~/.zshrc.local ]] && source ~/.zshrc.local
+
+fpath=(~/.zsh/completion /usr/local/share/zsh/site-functions $fpath)
+
+# completion
+autoload -U compinit
+compinit


### PR DESCRIPTION
After our reorganization of zsh configuration into separate files,
tab-completion for the `g` git function stopped working. This change
moves the setup for tab completion back into `zshrc` and restores the
completion functionality for `g`.