### PR TITLE
zsh: add editor files to zshenv

### DIFF
--- a/zsh/configs/editor.zsh
+++ b/zsh/configs/editor.zsh
@@ -1,2 +1,0 @@
-export VISUAL=vim
-export EDITOR=$VISUAL

--- a/zshenv
+++ b/zshenv
@@ -1,3 +1,6 @@
+export VISUAL=vim
+export EDITOR=$VISUAL
+
 local _old_path="$PATH"
 
 # Local config


### PR DESCRIPTION
The zshenv file seems like the canonical place to keep the editor config
variables. The change also allows for easier overriding for other
editors by adding the editor overrides to zshenv.local