### PR TITLE
Add golang configuration samples

### DIFF
--- a/vim/ftplugin/go.vim
+++ b/vim/ftplugin/go.vim
@@ -1,0 +1,6 @@
+let g:go_fmt_command = "goimports"
+
+setlocal softtabstop=2
+setlocal listchars=tab:\ \ ,trail:·,nbsp:·
+
+compiler go

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -28,8 +28,9 @@ call plug#begin('~/.vim/bundle')
 
 " Define bundles via Github repos
 Plug 'christoomey/vim-run-interactive'
-Plug 'kchmck/vim-coffee-script'
 Plug 'ctrlpvim/ctrlp.vim'
+Plug 'fatih/vim-go'
+Plug 'kchmck/vim-coffee-script'
 Plug 'pbrisbin/vim-mkdir'
 Plug 'scrooloose/syntastic'
 Plug 'slim-template/vim-slim'


### PR DESCRIPTION
* `softtabstop=2`: As a side effect of setting how "large" a tab is in
 insert mode, Vim is able to delete tabs with the backspace key in
 Insert mode.
* `compiler go`: Necessary for plugins using the `make` command, such as
 vim-dispatch.
* `listchars=tab:\ \ `: Don't highlight tabs as "»·" as if they were
 problem characters in go files. Also recommended for *sh files and any
 others which which should also be using tabs.
* `fatih/vim-go`: The de-facto Golang Vim plugin.