### PR TITLE
Use `export -U` to deduplicate `$PATH`

### DIFF
--- a/zsh/configs/post/path.zsh
+++ b/zsh/configs/post/path.zsh
@@ -9,6 +9,4 @@ fi
 # mkdir .git/safe in the root of repositories you trust
 PATH=".git/safe/../../bin:$PATH"
 
-typeset -U PATH
-
-export PATH
+export -U PATH


### PR DESCRIPTION
In f7c73f7c1bb9a902ee3752bd156c095e59469f46 we started to deduplicate
`$PATH` using `typeset -U`, but that did not prevent duplicate `$PATH`
entries when processes were launched that inherited the environment from
an existing shell.

Using `export -U` keeps the `$PATH` deduplicated even when tmux launches
a new shell.

Fix #443.