### PR TITLE
Don't export `$PS1`

### DIFF
--- a/zsh/configs/prompt.zsh
+++ b/zsh/configs/prompt.zsh
@@ -6,4 +6,4 @@ git_prompt_info() {
   fi
 }
 setopt promptsubst
-export PS1='${SSH_CONNECTION+"%{$fg_bold[green]%}%n@%m:"}%{$fg_bold[blue]%}%c%{$reset_color%}$(git_prompt_info) %# '
+PS1='${SSH_CONNECTION+"%{$fg_bold[green]%}%n@%m:"}%{$fg_bold[blue]%}%c%{$reset_color%}$(git_prompt_info) %# '


### PR DESCRIPTION
The `$PS1` variable does not need to be exported in order for `zsh` to
use its contents to set prompt options. `export`ing it has the negative
side-effect of polluting prompts in shells launched from `zsh`. The
`export`ing of `$PS1` is the cause of #270, where using `sudo su` to
become another user (launching a non-`zsh` shell) resulted in a
corrupted prompt.

Removing the `export` will allow `sh`/`bash`/`dash` and other shells to
be launched from `zsh` without inheriting its prompt settings.

Fix #270.