### PR TITLE
Add tab-completion with local branches for `git delete-branch`

### DIFF
--- a/zsh/functions/_git_delete_branch
+++ b/zsh/functions/_git_delete_branch
@@ -1,0 +1,4 @@
+_git_delete_branch ()
+{
+  __gitcomp "$(__git_heads)"
+}


### PR DESCRIPTION
This solution was heavily influenced by @keith's original contribution
in #356, which I think may have worked on some but not all setups due to
personal configuration differences.

The solution in #356 added the `_git_delete_branch` function in the
`zsh/completions` folder, which resulted in the tab-completion working
against `git`, but not against our `g` function. With our new loading
order where functions are loaded first and completions are loaded last,
we can load the `_git_delete_branch` function before any completions are
defined on `git`, `g`, or `hub`, allowing the `_git_delete_branch` shim
to be used by all three of those git-invoking commands/functions.

Thank you to @keith for doing the heavy lifting here that provided the template for the solution.

Close #355.