### PR TITLE
Set `<leader>ct` shortcut to use Git ctags hook

### DIFF
--- a/vim/plugin/ctags.vim
+++ b/vim/plugin/ctags.vim
@@ -1,0 +1,15 @@
+" Exclude Javascript files in :Rtags via rails.vim due to warnings when parsing
+let g:Tlist_Ctags_Cmd="ctags --exclude='*.js'"
+
+" Index ctags from any project, including those outside Rails
+function! ReindexCtags()
+  let l:ctags_hook = '$(git rev-parse --show-toplevel)/.git/hooks/ctags'
+
+  if exists(l:ctags_hook)
+    exec '!'. l:ctags_hook
+  else
+    exec "!ctags -R ."
+  endif
+endfunction
+
+nmap <Leader>ct :call ReindexCtags()<CR>

--- a/vimrc
+++ b/vimrc
@@ -103,12 +103,6 @@ endfunction
 inoremap <Tab> <c-r>=InsertTabWrapper()<cr>
 inoremap <S-Tab> <c-n>
 
-" Exclude Javascript files in :Rtags via rails.vim due to warnings when parsing
-let g:Tlist_Ctags_Cmd="ctags --exclude='*.js'"
-
-" Index ctags from any project, including those outside Rails
-map <Leader>ct :!ctags -R .<CR>
-
 " Switch between the last two files
 nnoremap <leader><leader> <c-^>
 


### PR DESCRIPTION
In cbdcbce01dea1ab3850be2311f33f00d75f6088b we introduced a Tim
Pope-inspired Git template scheme that automatically ran `ctags`
asynchronously through a hook after certain source control operations.
This hook is bypassed if a user uses `<leader>ct` to reindex their tags
from within Vim.

This change binds `<leader>ct` to use a Vimscript function that will
identify if the `ctags` hook exists in the local repository and executes
it. The function falls back to existing functionality if the hook does
not exist.