### PR TITLE
Run `db:test:prepare` task on `migrate` alias

### DIFF
--- a/aliases
+++ b/aliases
@@ -9,7 +9,7 @@ alias v="$VISUAL"
 alias b="bundle"
 
 # Rails
-alias migrate="rake db:migrate db:rollback && rake db:migrate"
+alias migrate="rake db:migrate db:rollback && rake db:migrate db:test:prepare"
 alias s="rspec"
 
 # Pretty print the path


### PR DESCRIPTION
We use the `migrate` shell alias to run migrations, roll back one step,
then migrate again. In addition to serving as a handy shortcut for `rake
db:migrate`, it helps us test whether or not migrations are fully
reversible.

If a migration is rolled back and edited, then migrated forward, the
change may not be reflected in the test database, which can cause
unexpected errors when the development and test DB schema do not match.
This change runs the `db:test:prepare` task after migrations complete to
ensure that the test database schema matches the schema defined in the
application's `db/schema.rb` or `db/struture.sql`.