### PR TITLE
[replace script] to be compatible with GNU/Linux

### DIFF
--- a/bin/replace
+++ b/bin/replace
@@ -9,4 +9,6 @@ shift
 replace_with="$1"
 shift
 
-ag -l --nocolor "$find_this" "$@" | xargs sed -i '' "s/$find_this/$replace_with/g"
+items=$(ag -l --nocolor "$find_this" "$@")
+temp="${TMPDIR:-/tmp}/replace_temp_file.$$"
+for item in $items; do sed "s/$find_this/$replace_with/g" $item > $temp && mv $temp $item; done


### PR DESCRIPTION
```sed -i ''``` is not working in Debian Jessie (I think GNU/Linux in general).
error:
```sed: can't read <sed expression>: No such file or directory```
sed (GNU sed) 4.2.2

What it works is:
```sed -i""``` or ```sed -i''``` or ```sed -i```