### PR TITLE
Use one space, not two, after punctuation.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -68,6 +68,9 @@ set expandtab
 " Display extra whitespace
 set list listchars=tab:»·,trail:·,nbsp:·
 
+" Use one space, not two, after punctuation.
+set nojoinspaces
+
 " Use The Silver Searcher https://github.com/ggreer/the_silver_searcher
 if executable('ag')
   " Use Ag over Grep


### PR DESCRIPTION
When using a join command (`gq`, `J`), vim defaults to adding two spaces
after '.', '?', and '!'.

Setting `nojoinspaces` causes vim to only insert a single space.

```
:help joinspaces

			*'joinspaces'* *'js'* *'nojoinspaces'* *'nojs'*
'joinspaces' 'js'	boolean	(default on)
			global
			{not in Vi}
	Insert two spaces after a '.', '?' and '!' with a join command.
	When 'cpoptions' includes the 'j' flag, only do this after a '.'.
	Otherwise only one space is inserted.
	NOTE: This option is set when 'compatible' is set.
```