### PR TITLE
Remove existing PR message when creating a PR

### DIFF
--- a/bin/git-pr
+++ b/bin/git-pr
@@ -2,4 +2,4 @@
 
 set -e
 
-hub pull-request
+rm -rf "$(git rev-parse --git-dir)"/PULLREQ_EDITMSG && hub pull-request


### PR DESCRIPTION
When creating a pull request with the `git-pr` command or `hub pull-request`, it is not possible to abort the creation of the PR by quitting Vim without writing in a similar fashion to aborting a commit with `:q!`.

Killing the Vim process succeeds in not creating the PR, but leaves behind the originally-built pull request content in `.git/PULLREQ_EDITMSG`. Upon switching branches or re-attempting to create the PR in the same branch, the content is already populated and is often incorrect.

This can be a rude surprise when attempting to create a single-commit PR and expecting the PR content to match your well-crafted commit message and `hub` suggests the contents of your last PR instead of your current commit.

This change deletes the left behind PR message before running `hub pull-request` to ensure that `hub` builds PR content from the current unmerged commits in the current branch.