### PR TITLE
Extract filetype-specific setup to ftplugin

### DIFF
--- a/vim/ftplugin/css.vim
+++ b/vim/ftplugin/css.vim
@@ -1,0 +1,1 @@
+setlocal iskeyword+=-

--- a/vim/ftplugin/gitcommit.vim
+++ b/vim/ftplugin/gitcommit.vim
@@ -1,0 +1,3 @@
+" Automatically wrap at 72 characters and spell check commit messages
+setlocal textwidth=72
+setlocal spell

--- a/vim/ftplugin/markdown.vim
+++ b/vim/ftplugin/markdown.vim
@@ -1,0 +1,5 @@
+" Enable spellchecking
+setlocal spell
+
+" Automatically wrap at 80 characters
+setlocal textwidth=80

--- a/vim/ftplugin/sass.vim
+++ b/vim/ftplugin/sass.vim
@@ -1,0 +1,1 @@
+setlocal iskeyword+=-

--- a/vim/ftplugin/scss.vim
+++ b/vim/ftplugin/scss.vim
@@ -1,0 +1,1 @@
+setlocal iskeyword+=-

--- a/vimrc
+++ b/vimrc
@@ -44,19 +44,6 @@ augroup vimrcEx
   autocmd BufRead,BufNewFile Appraisals set filetype=ruby
   autocmd BufRead,BufNewFile *.md set filetype=markdown
   autocmd BufRead,BufNewFile .{jscs,jshint,eslint}rc set filetype=json
-
-  " Enable spellchecking for Markdown
-  autocmd FileType markdown setlocal spell
-
-  " Automatically wrap at 80 characters for Markdown
-  autocmd BufRead,BufNewFile *.md setlocal textwidth=80
-
-  " Automatically wrap at 72 characters and spell check git commit messages
-  autocmd FileType gitcommit setlocal textwidth=72
-  autocmd FileType gitcommit setlocal spell
-
-  " Allow stylesheets to autocomplete hyphenated words
-  autocmd FileType css,scss,sass setlocal iskeyword+=-
 augroup END
 
 " Softtabs, 2 spaces


### PR DESCRIPTION
Vim's documentation advises that buffer-specific configuration based on
a filetype should be performed via a file in `$HOME/.vim/ftplugin`:
http://vimdoc.sourceforge.net/htmldoc/usr_41.html#41.12

This change moves Git commit message- and Markdown-related editor
settings into `ftplugin/gitcommit.vim` and `ftplugin/markdown.vim`, and
rewrites those settings to avoid using `autocmd`, letting Vim execute
`setlocal` when a file of the filetype is determined or set.

This organization of single-filetype-specific configurations could serve as
a template for language-specific settings such as https://github.com/thoughtbot/dotfiles/pull/449.