### PR TITLE
Better match the default behavior of ctrl-P when using ag

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -64,7 +64,7 @@ if executable('ag')
   set grepprg=ag\ --nogroup\ --nocolor
 
   " Use ag in CtrlP for listing files. Lightning fast and respects .gitignore
-  let g:ctrlp_user_command = 'ag %s -l --nocolor --hidden -g ""'
+  let g:ctrlp_user_command = 'ag -Q -l --nocolor --hidden -g "" %s'
 
   " ag is fast enough that CtrlP doesn't need to cache
   let g:ctrlp_use_caching = 0


### PR DESCRIPTION
When using ctrl-p without ag, the pattern given is not treated as a regular expression. Additionally, the value passed when first opening ctrl-p is not actually a valid PCRE regex, and produces an error when used on Windows. This modifies the options to treat the pattern as a string literal, not a regular expression, resolving the Windows problem, and better matching the behavior of ctrl-p without Ag.