### PR TITLE
Add `install-missing-ruby` alias

### DIFF
--- a/aliases
+++ b/aliases
@@ -5,10 +5,9 @@ alias mkdir="mkdir -p"
 alias e="$EDITOR"
 alias v="$VISUAL"
 
-# Bundler
+# Ruby
 alias b="bundle"
-
-# Rails
+alias install-missing-ruby="brew update && brew upgrade ruby-build && rbenv install"
 alias migrate="rake db:migrate db:rollback && rake db:migrate db:test:prepare"
 alias s="rspec"
 


### PR DESCRIPTION
Sometimes I don't have installed on my machine
the Ruby version that the project requires.
Almost every project uses the `.ruby-version` convention.
I type `install-missing-ruby` (or tab complete a few characters)
and the version of Ruby is installed.