### PR TITLE
Remove aliases that are no longer included

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,6 @@ configuration:
 Shell aliases and scripts:
 
 * `b` for `bundle`.
-* `g` with no arguments is `git status` and with arguments acts like `git`.
-* `git-churn` to show churn for the files changed in the branch.
 * `migrate` for `rake db:migrate && rake db:rollback && rake db:migrate`.
 * `mcd` to make a directory and change into it.
 * `replace foo bar **/*.rb` to find and replace within a given list of files.


### PR DESCRIPTION
The README points to some aliases that are no longer included in the `.aliases` file, and should be removed.