### PR TITLE
Set the default shell type to POSIX in vim

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -46,6 +46,10 @@ augroup vimrcEx
   autocmd BufRead,BufNewFile .{jscs,jshint,eslint}rc set filetype=json
 augroup END
 
+" When the type of shell script is /bin/sh, assume a POSIX-compatible
+" shell for syntax highlighting purposes.
+let g:is_posix = 1
+
 " Softtabs, 2 spaces
 set tabstop=2
 set shiftwidth=2


### PR DESCRIPTION
If it can't be determined that a shell script is either `bash` or `ksh`, use `posix` as the default instead of plain `sh`. It seems unlikely that `/bin/sh` wouldn't be a POSIX-compliant shell on modern systems.

See [`:help ft-sh-syntax`](http://vimdoc.sourceforge.net/htmldoc/syntax.html#ft-sh-syntax) and [this thread on /r/vim](https://www.reddit.com/r/vim/comments/25g1sp/why_doesnt_vim_syntax_like_my_shell_files/chlc4ep) for more info.

This fixes the issue where `$(...)` syntax in shell scripts is highlighted as an error in vim.