### PR TITLE
Add hub support to the g function

### DIFF
--- a/bin/git-pr
+++ b/bin/git-pr
@@ -2,4 +2,12 @@
 
 set -e
 
-hub pull-request
+if command -v hub >/dev/null; then
+  hub pull-request
+else
+  cat <<MSG >&2
+This command depends upon 'hub', which was not found.
+Visit https://hub.github.com for installation instructions.
+
+MSG
+fi

--- a/zsh/functions/g
+++ b/zsh/functions/g
@@ -1,9 +1,18 @@
 # No arguments: `git status`
 # With arguments: acts like `git`
+# Uses `hub` if available
 g() {
-  if [[ $# -gt 0 ]]; then
-    git "$@"
+  local _git
+
+  if command -v hub >/dev/null; then
+    _git=hub
   else
-    git status
+    _git=git
+  fi
+
+  if [[ $# -gt 0 ]]; then
+    $_git "$@"
+  else
+    $_git status
   fi
 }


### PR DESCRIPTION
Since the [`g` function](https://github.com/thoughtbot/dotfiles/blob/master/zsh/functions/g) doesn't have access to a [`git='hub'` alias](https://github.com/github/hub#aliasing), we can't run `hub` commands through it.

This checks for `hub` in the `g` function and uses it instead of `git` in the event that it's found.

It also adds a similar check for `hub` before invoking it in [`git-pr`](https://github.com/thoughtbot/dotfiles/blob/master/bin/git-pr).