### PR TITLE
Avoid expanding tabs to spaces for Golang files

### DIFF
--- a/vim/ftplugin/go.vim
+++ b/vim/ftplugin/go.vim
@@ -1,6 +1,6 @@
 let g:go_fmt_command = "goimports"
 
-setlocal softtabstop=2
 setlocal listchars=tab:\ \ ,trail:·,nbsp:·
+setlocal noexpandtab
 
 compiler go


### PR DESCRIPTION
* `noexpandtab` will ensure tabs are used instead of staces when tabbing
or auto-indenting.
* `softtabstop=2` isn't needed because we are already setting
`tabstop=2` in our `.vimrc`.