### PR TITLE
Overwrite internal field separator when replacing.

### DIFF
--- a/bin/replace
+++ b/bin/replace
@@ -11,6 +11,7 @@ shift
 
 items=$(ag -l --nocolor "$find_this" "$@")
 temp="${TMPDIR:-/tmp}/replace_temp_file.$$"
+IFS=$'\n'
 for item in $items; do
   sed "s/$find_this/$replace_with/g" "$item" > "$temp" && mv "$temp" "$item"
 done


### PR DESCRIPTION
Problem:
Currently the `for` in bash will break up lists by whitespace, so if a
filename has a space in it the `for` will break it up incorrectly.

AG will separate the files with a newline character, so this temporarily
overwrites the `IFS` to be used correctly for this use case.

[Docs](https://bash.cyberciti.biz/guide/$IFS)