### PR TITLE
Git ignore .byebug_history

### DIFF
--- a/gitignore
+++ b/gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 *.sw[nop]
 .bundle
+.byebug_history
 .env
 db/*.sqlite3
 log/*.log


### PR DESCRIPTION
After using byebug on any Ruby file, the sessions history is written to
this file. It shouldn't be part of our repositories, so we ignore it.

See also: https://github.com/thoughtbot/suspenders/pull/710, where @ivobenedito started work on this.