### PR TITLE
Add a zsh binding for push-line-or-edit

### DIFF
--- a/zsh/configs/keybindings.zsh
+++ b/zsh/configs/keybindings.zsh
@@ -1,3 +1,6 @@
+# give us access to ^Q
+stty -ixon
+
 # vi mode
 bindkey -v
 bindkey "^F" vi-cmd-mode
@@ -10,4 +13,5 @@ bindkey "^R" history-incremental-search-backward
 bindkey "^P" history-search-backward
 bindkey "^Y" accept-and-hold
 bindkey "^N" insert-last-word
+bindkey "^Q" push-line-or-edit
 bindkey -s "^T" "^[Isudo ^[A" # "t" for "toughguy"


### PR DESCRIPTION
The use case for push-line-or-edit:

1. You are in the middle of typing a long command, perhaps something
involving `tar`.
2. You realize that you must first run another command, such as `man
tar`.
3. You invoke `push-line-or-edit`, which gives you a fresh prompt. You
type `man tar` and read as needed.
4. When the command (`man tar`) finishes, the long command you
half-typed is back, exactly as you left off.

Other use cases are realizing that you're in the wrong directory before
you press enter, changing your Ruby version before you press enter on
that `bundle` command, or in general being partway through something and
realizing that you're not quite ready to run it yet.

I picked <kbd><kbd>CTRL</kbd><kbd>B</kbd></kbd> arbitrarily; let me know if you have a more natural keybinding.