### PR TITLE
Use vim-polyglot instead of individual syntaxes

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -29,12 +29,10 @@ call plug#begin('~/.vim/bundle')
 " Define bundles via Github repos
 Plug 'christoomey/vim-run-interactive'
 Plug 'ctrlpvim/ctrlp.vim'
-Plug 'fatih/vim-go'
 Plug 'janko-m/vim-test'
-Plug 'kchmck/vim-coffee-script'
 Plug 'pbrisbin/vim-mkdir'
 Plug 'scrooloose/syntastic'
-Plug 'slim-template/vim-slim'
+Plug 'sheerun/vim-polyglot'
 Plug 'tpope/vim-bundler'
 Plug 'tpope/vim-endwise'
 Plug 'tpope/vim-eunuch'
@@ -45,7 +43,6 @@ Plug 'tpope/vim-rake'
 Plug 'tpope/vim-repeat'
 Plug 'tpope/vim-rhubarb'
 Plug 'tpope/vim-surround'
-Plug 'vim-ruby/vim-ruby'
 Plug 'vim-scripts/tComment'
 
 if filereadable(expand("~/.vimrc.bundles.local"))


### PR DESCRIPTION
Hey, I thought I'd propose to use my syntax plugin instead of multiple syntaxes. You can read the advantages here: https://github.com/sheerun/vim-polyglot

I maintain plugin for more than 3 years and it doesn't seem to change in near future.