### PR TITLE
Keep swap files in case of crash

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -4,7 +4,6 @@ let mapleader = " "
 set backspace=2   " Backspace deletes like most programs in insert mode
 set nobackup
 set nowritebackup
-set noswapfile    " http://robots.thoughtbot.com/post/18739402579/global-gitignore#comment-458413287
 set history=50
 set ruler         " show the cursor position all the time
 set showcmd       " display incomplete commands


### PR DESCRIPTION
Reference: http://vi.stackexchange.com/questions/177/what-is-the-purpose-of-swap-files

Instead, just set *.swp to be ignored in .gitignore_global