### PR TITLE
Update install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Install
 
 Clone onto your laptop:
 
-    git clone git://github.com/thoughtbot/dotfiles.git
+    git clone git://github.com/thoughtbot/dotfiles.git ~/dotfiles
 
 (Or, [fork and keep your fork
 updated](http://robots.thoughtbot.com/keeping-a-github-fork-updated)).


### PR DESCRIPTION
In #488 there was some confusion over where to clone the dotfiles
repository before running `rcm`. While the repository can be placed
anywhere, by default users should be placing it in `~/dotfiles` if they
are using the default installation instructions and an unmodified
`.rcrc`.

Close #488.