### PR TITLE
Use "absolute" paths for agignore

### DIFF
--- a/agignore
+++ b/agignore
@@ -1,7 +1,7 @@
-log
-tags
-tmp
-vendor
 .git/
-bower_components/
-node_modules/
+tags
+/bower_components/
+/log
+/node_modules/
+/tmp
+/vendor


### PR DESCRIPTION
This seems to resolve an issue where CtrlP would randomly return "NO
ENTRIES".

See https://forum.upcase.com/t/ctrlp-sometimes-displays-no-entries/5658

This also sorts the paths alphabetically, because OCD. :tada: