### PR TITLE
Add Ag mappings in vim

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -72,6 +72,11 @@ if executable('ag')
 
   " ag is fast enough that CtrlP doesn't need to cache
   let g:ctrlp_use_caching = 0
+
+  if !exists(":Ag")
+    command -nargs=+ -complete=file -bar Ag silent! grep! <args>|cwindow|redraw!
+    nnoremap \ :Ag<SPACE>
+  endif
 endif
 
 " Make it obvious where 80 characters is


### PR DESCRIPTION
https://robots.thoughtbot.com/faster-grepping-in-vim

- Create an `:Ag` command if none is defined to perform a search with `Ag` and render results in quickfix window
- map `\` in normal mode to set up the command for an argument