### PR TITLE
[Vim] Don't open first result by default with \

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -75,7 +75,7 @@ if executable('ag')
 
   if !exists(":Ag")
     command -nargs=+ -complete=file -bar Ag silent! grep! <args>|cwindow|redraw!
-    nnoremap \ :Ag<SPACE>
+    nnoremap \ :Ag!<SPACE>
   endif
 endif
 


### PR DESCRIPTION
By default Ag.vim open the first result (https://github.com/thoughtbot/dotfiles/commit/e51d8b73f0d8ab99d1a12efdfbcd6dd287bec15c). To avoid it you can add a bang.

Their is a PR to make it default but it's not merge : https://github.com/rking/ag.vim/issues/119