### PR TITLE
Set 'autowrite'

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -10,6 +10,7 @@ set ruler         " show the cursor position all the time
 set showcmd       " display incomplete commands
 set incsearch     " do incremental searching
 set laststatus=2  " Always display the status line
+set autowrite     " Automatically :write before running commands
 
 " Switch syntax highlighting on, when the terminal has colors
 " Also switch on highlighting the last used search pattern.


### PR DESCRIPTION
* Automatically :write before commands such as `:next` or `:!`
* Saves keystrokes by eliminating writes before running tests, etc
* See `:help 'autowrite'` for more information