### PR TITLE
Add pre-push git hook

### DIFF
--- a/git_template/hooks/pre-push
+++ b/git_template/hooks/pre-push
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+local_hook="$HOME"/.git_template.local/hooks/pre-push
+
+if [ -f "$local_hook" ]; then
+  . "$local_hook"
+fi


### PR DESCRIPTION
Adds a pre-push git hook that calls the local pre-push git hook

I discovered this is useful when trying to add a pre-push hook that warns me when I push to `master`. I guess it's overkill to add all possible git hooks, but this one at least I found a real world use case for.
