### PR TITLE
Allow user to ignore some default vim plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,24 @@ Your `~/dotfiles-local/vimrc.local` might look like this:
     highlight NonText guibg=#060606
     highlight Folded  guibg=#0A0A0A guifg=#9090D0
 
+If you don't wish to install a vim plugin from the default set of vim plugins in
+`.vimrc.bundles`, you can ignore the plugin by calling it out with `UnPlug` in
+your `~/.vimrc.bundles.local`.
+
+    " Don't install vim-scripts/tComment
+    UnPlug 'tComment'
+
+`UnPlug` can be used to install your own fork of a plugin or to install a shared
+plugin with different custom options.
+
+    " Only load vim-coffee-script if a Coffeescript buffer is created
+    UnPlug 'vim-coffee-script'
+    Plug 'kchmck/vim-coffee-script', { 'for': 'coffee' }
+
+    " Use a personal fork of vim-run-interactive
+    UnPlug 'vim-run-interactive'
+    Plug '$HOME/plugins/vim-run-interactive'
+
 To extend your `git` hooks, create executable scripts in
 `~/dotfiles-local/git_template.local/hooks/*` files.
 

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -2,6 +2,14 @@ if &compatible
   set nocompatible
 end
 
+" Remove declared plugins
+function! s:UnPlug(plug_name)
+  if has_key(g:plugs, a:plug_name)
+    call remove(g:plugs, a:plug_name)
+  endif
+endfunction
+command!  -nargs=1 UnPlug call s:UnPlug(<args>)
+
 " Shim command and function to allow migration from Vundle to vim-plug.
 function! VundleToPlug(vundle_command, arg, ...)
   echom "You are using Vundle's `".a:vundle_command."` command to declare plugins. Dotfiles now uses vim-plug for plugin management. Please rename uses of `".a:vundle_command."` to `Plug`. Plugin was '".a:arg."'."


### PR DESCRIPTION
This change wraps calls to `vim-plug`'s `Plug` command in
`vimrc.bundles` in a new command that first checks if the user has
blacklisted the plugin in `g:plugins_to_ignore`.

Users can declare their plugin blacklist in `$HOME/.vimrc.ignorebundles`.
