### PR TITLE
Add `editorconfig-vim`

### DIFF
--- a/vim/plugin/editorconfig.vim
+++ b/vim/plugin/editorconfig.vim
@@ -1,0 +1,1 @@
+let g:EditorConfig_exclude_patterns = ['fugitive://.*']

--- a/vim/plugin/editorconfig.vim
+++ b/vim/plugin/editorconfig.vim
@@ -1,1 +1,2 @@
+" Disable editconfig for fugitive
 let g:EditorConfig_exclude_patterns = ['fugitive://.*']

--- a/vimrc
+++ b/vimrc
@@ -150,6 +150,9 @@ set complete+=kspell
 " Always use vertical diffs
 set diffopt+=vertical
 
+" Disable editconfig for fugitive
+let g:EditorConfig_exclude_patterns = ['fugitive://.*']
+
 " Local config
 if filereadable($HOME . "/.vimrc.local")
   source ~/.vimrc.local

--- a/vimrc
+++ b/vimrc
@@ -150,9 +150,6 @@ set complete+=kspell
 " Always use vertical diffs
 set diffopt+=vertical
 
-" Disable editconfig for fugitive
-let g:EditorConfig_exclude_patterns = ['fugitive://.*']
-
 " Local config
 if filereadable($HOME . "/.vimrc.local")
   source ~/.vimrc.local

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -29,6 +29,7 @@ call plug#begin('~/.vim/bundle')
 " Define bundles via Github repos
 Plug 'christoomey/vim-run-interactive'
 Plug 'ctrlpvim/ctrlp.vim'
+Plug 'editorconfig/editorconfig-vim'
 Plug 'fatih/vim-go'
 Plug 'janko-m/vim-test'
 Plug 'kchmck/vim-coffee-script'


### PR DESCRIPTION
Many projects are now using a `.editorconfig` file to share coding styles across editors. This adds support to vim for reading a project's `.editorconfig`.

See: http://editorconfig.org/