### PR TITLE
Add git dirty status to zsh prompt

### DIFF
--- a/zsh/configs/prompt.zsh
+++ b/zsh/configs/prompt.zsh
@@ -1,9 +1,28 @@
 # modify the prompt to contain git branch name if applicable
 git_prompt_info() {
-  current_branch=$(git current-branch 2> /dev/null)
-  if [[ -n $current_branch ]]; then
-    echo " %{$fg_bold[green]%}$current_branch%{$reset_color%}"
+  local ref=$(=git symbolic-ref HEAD 2> /dev/null)
+  local gitst="$(=git status 2> /dev/null)"
+
+  if [[ -f .git/MERGE_HEAD ]]; then
+    if [[ ${gitst} =~ "unmerged" ]]; then
+      gitstatus=" %{$fg[red]%}unmerged%{$reset_color%}"
+    else
+      gitstatus=" %{$fg[green]%}merged%{$reset_color%}"
+    fi
+  elif [[ ${gitst} =~ "Changes to be committed" ]]; then
+    gitstatus=" %{$fg[blue]%}!%{$reset_color%}"
+  elif [[ ${gitst} =~ "use \"git add" ]]; then
+    gitstatus=" %{$fg[red]%}!%{$reset_color%}"
+  elif [[ -n `git checkout HEAD 2> /dev/null | grep ahead` ]]; then
+    gitstatus=" %{$fg[cyan]%}*%{$reset_color%}"
+  else
+    gitstatus=''
+  fi
+
+  if [[ -n $ref ]]; then
+    echo "%{$fg_bold[orange]%} ${ref#refs/heads/}%{$reset_color%}$gitstatus"
   fi
 }
+
 setopt promptsubst
 PS1='${SSH_CONNECTION+"%{$fg_bold[green]%}%n@%m:"}%{$fg_bold[blue]%}%c%{$reset_color%}$(git_prompt_info) %# '


### PR DESCRIPTION
I thought it would be nice to have a git status indicator included in the dotfiles by default.

- Displays a red exclamation mark when unstaged changes exist
- Displays a blue exclamation mark when staged changes exist
- Display a cyan asterisk when unpushed commits exist

Both exclamation marks representing uncommitted changes will take precedent over the asterisk.

![git-status-zsh-prompt](https://cloud.githubusercontent.com/assets/6628875/21897226/f98a848e-d8b6-11e6-82a5-a5ad126e9707.gif)
