### PR TITLE
Explicitly specify no input from terminal in post-up hook

### DIFF
--- a/hooks/post-up
+++ b/hooks/post-up
@@ -6,7 +6,7 @@ if [ ! -e "$HOME"/.vim/autoload/plug.vim ]; then
   curl -fLo "$HOME"/.vim/autoload/plug.vim --create-dirs \
       https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 fi
-vim -u "$HOME"/.vimrc.bundles +PlugInstall +PlugClean! +qa
+vim -u "$HOME"/.vimrc.bundles +PlugInstall +PlugClean! +qa -
 
 # detect old OS X broken /etc/zshenv and suggest rename
 if grep -qw path_helper /etc/zshenv 2>/dev/null; then


### PR DESCRIPTION
This change prevents the `post-up` hook from breaking the terminal for
the rest of the session when running `rcup` with a `Vim: Warning: Input is not from a terminal`.

Since the session is completely automated, we don't need input from the terminal once Vim
launches.