### PR TITLE
Unbind the shortcut for suspend-client

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -35,5 +35,8 @@ bind-key C-b send-prefix
 # prefix-2 -> forward-incremental-history-search
 bind-key C-s send-prefix -2
 
+# don't suspend-client
+unbind-key C-z
+
 # Local config
 if-shell "[ -f ~/.tmux.conf.local ]" 'source ~/.tmux.conf.local'


### PR DESCRIPTION
Why:

I occasionally will try to zoom in on a pane with the key combination of
C-s then z. However, instead of having the agility to remove my finger
from the ctrl key, I clumsily continue to have it depressed while
applying pressure to the z key. This results in the `suspend-client`
command being executed by tmux. I am then left not knowing what to do
and I can't reattach to the session the that terminal window. It's very
disconcerting and I wish it hadn't happened.

This PR:

Removes the binding for `suspend-client`.