### PR TITLE
Run `reset` in post-up hook to fix terminal issue

### DIFF
--- a/hooks/post-up
+++ b/hooks/post-up
@@ -8,6 +8,8 @@ if [ ! -e "$HOME"/.vim/autoload/plug.vim ]; then
 fi
 vim -u "$HOME"/.vimrc.bundles +PlugInstall +PlugClean! +qa
 
+reset -Q
+
 # detect old OS X broken /etc/zshenv and suggest rename
 if grep -qw path_helper /etc/zshenv 2>/dev/null; then
   if [ -t 2 ]; then


### PR DESCRIPTION
Some tmux users have reported that when running `rcup` that during the
post-up hook Vim would issue errors about input not coming from a
terminal and then the terminal would look and behave unexpectedly.

Running `reset` after the Vim plugin install step in `post-up` appears
to resolve the issue.

Fix #516.