### PR TITLE
Don't rely on Bash in post-up hook

### DIFF
--- a/hooks/post-up
+++ b/hooks/post-up
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 touch "$HOME"/.psqlrc.local
 
@@ -12,31 +12,15 @@ reset -Q
 
 # detect old OS X broken /etc/zshenv and suggest rename
 if grep -qw path_helper /etc/zshenv 2>/dev/null; then
-  if [ -t 2 ]; then
-    fg_red=$'\e[31m'
-    fg_bold_white=$'\e[1;37m'
-    reset_color=$'\e[m'
-  else
-    fg_red=""
-    fg_bold_white=""
-    reset_color=""
-  fi
-
-  # resolve BASH_SOURCE to absolute path
-  bash_source="$BASH_SOURCE"
-  if [[ $bash_source == */* ]]; then
-    pushd "${bash_source%/*}" >/dev/null
-    bash_source="${PWD}/${bash_source##*/}"
-    popd >/dev/null
-  fi
+  dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
 
   cat <<MSG >&2
-${fg_red}Warning:${reset_color} \`/etc/zshenv' configuration file on your system may cause unexpected
+Warning: \`/etc/zshenv' configuration file on your system may cause unexpected
 PATH changes on subsequent invocations of the zsh shell. The solution is to
 rename the file to \`zprofile':
-  ${fg_bold_white}sudo mv /etc/{zshenv,zprofile}${reset_color}
+  sudo mv /etc/{zshenv,zprofile}
 
-(called from ${bash_source}:${LINENO})
+(called from ${dir}/post-up:${LINENO})
 
 MSG
 fi


### PR DESCRIPTION
In 16219a31db5ca1f8c766d3c6066399950ff7f2c3 we implemented a post-up
hook that checked for a problematic `/etc/zshenv` file. OSX/macOS has
changed the file responsible for executing `path_helper` and loading the
system paths multiple times, and this script change issued a warning to
users if `path_helper` might be called in such a way that their paths
could be unexpectedly reordered.

The script used colored output to highlight this problem for the user,
and relied on Bash's script path introspection (through `$BASH_SOURCE`)
to print the location of the `post-up` hook to assist the user in
troubleshooting and understanding where our warning came from.

This change removes the hook's reliance on GNU Bash in favor of `sh`. It
uses the POSIX-compliant `$0` to determine the hook location (this
method is less robust than Bash's `$BASH_SOURCE`, but is available in
all POSIX shells) and removes colored output in the warning to be
compatible with shells that don't support colored output.

Fix #517.