### PR TITLE
Skip compiled wordcode files (ie. zwc extensions)

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -10,6 +10,7 @@ _load_settings() {
   if [ -d "$_dir" ]; then
     if [ -d "$_dir/pre" ]; then
       for config in "$_dir"/pre/**/*(N-.); do
+        if [ ${config:e} = "zwc" ] ; then continue ; done
         . $config
       done
     fi
@@ -24,6 +25,7 @@ _load_settings() {
           ;;
         *)
           if [ -f $config ]; then
+            if [ ${config:e} = "zwc" ] ; then continue ; done
             . $config
           fi
           ;;
@@ -32,6 +34,7 @@ _load_settings() {
 
     if [ -d "$_dir/post" ]; then
       for config in "$_dir"/post/**/*(N-.); do
+        if [ ${config:e} = "zwc" ] ; then continue ; done
         . $config
       done
     fi

--- a/zshrc
+++ b/zshrc
@@ -10,7 +10,7 @@ _load_settings() {
   if [ -d "$_dir" ]; then
     if [ -d "$_dir/pre" ]; then
       for config in "$_dir"/pre/**/*(N-.); do
-        if [ ${config:e} = "zwc" ] ; then continue ; done
+        if [ ${config:e} = "zwc" ] ; then continue ; fi
         . $config
       done
     fi
@@ -24,8 +24,7 @@ _load_settings() {
           :
           ;;
         *)
-          if [ -f $config ]; then
-            if [ ${config:e} = "zwc" ] ; then continue ; done
+          if [ -f $config && ${config:e} != "zwc" ]; then
             . $config
           fi
           ;;
@@ -34,7 +33,7 @@ _load_settings() {
 
     if [ -d "$_dir/post" ]; then
       for config in "$_dir"/post/**/*(N-.); do
-        if [ ${config:e} = "zwc" ] ; then continue ; done
+        if [ ${config:e} = "zwc" ] ; then continue ; fi
         . $config
       done
     fi


### PR DESCRIPTION
zcompiled files will cause errors for the zsh script as it starts.