### PR TITLE
fix #524, update plugins

### DIFF
--- a/hooks/post-up
+++ b/hooks/post-up
@@ -2,11 +2,11 @@
 
 touch "$HOME"/.psqlrc.local
 
-if [ ! -e "$HOME"/.vim/autoload/plug.vim ]; then
+if [ -e "$HOME"/.vim/autoload/plug.vim ]; then
+  vim -E -s +PlugUpgrade +qa
+else
   curl -fLo "$HOME"/.vim/autoload/plug.vim --create-dirs \
       https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
-else
-  vim -E -s +PlugUpgrade +qa
 fi
 vim -u "$HOME"/.vimrc.bundles +PlugUpdate +PlugClean! +qa
 

--- a/hooks/post-up
+++ b/hooks/post-up
@@ -5,8 +5,10 @@ touch "$HOME"/.psqlrc.local
 if [ ! -e "$HOME"/.vim/autoload/plug.vim ]; then
   curl -fLo "$HOME"/.vim/autoload/plug.vim --create-dirs \
       https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+else
+  vim -E -s +PlugUpgrade +qa
 fi
-vim -u "$HOME"/.vimrc.bundles +PlugInstall +PlugClean! +qa
+vim -u "$HOME"/.vimrc.bundles +PlugUpdate +PlugClean! +qa
 
 reset -Q
 


### PR DESCRIPTION
* updating and upgrading existing plugins seems consistent with the idea of [rcup](http://thoughtbot.github.io/rcm/rcup.1.html)
* if .vim/autoload/plug.vim already exists, then use PlugUpgrade to get the newest version. This should also fix #524.
* change from PlugInstall to PlugUpdate which doesn't just install new plugins but also updates existing ones.