### PR TITLE
Add `bin/git-trust-bin` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ any new files in the repository.
 Make your own customizations
 ----------------------------
 
-Create a directory for your personal customizations: 
+Create a directory for your personal customizations:
 
     mkdir ~/dotfiles-local
 
@@ -209,6 +209,7 @@ configuration:
 * Adds `post-{checkout,commit,merge}` hooks to re-index your ctags.
 * Adds `pre-commit` and `prepare-commit-msg` stubs that delegate to your local
   config.
+* Adds `trust-bin` alias to append a project's `bin/` directory to `$PATH`.
 
 [Ruby](https://www.ruby-lang.org/en/) configuration:
 

--- a/bin/git-trust-bin
+++ b/bin/git-trust-bin
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+mkdir -p .git/safe


### PR DESCRIPTION
To [append a project's local `bin/` directory to `$PATH`][dotfiles],
the dotfiles check for the existence of a special directory: `git/.safe`.

This commit is inspired by [thoughtbot/suspenders#837][#837]:

> The idea behind the .git/safe is that I run it manually and explicitly
> after I trust the directoy and the team behind the project.

> Creating it as part of the setup script defeats the point of that. Doing
> so without explcitly telling the user comes across as sneaky, perhaps.
> (I do expect all devs to read setup scripts before running them -- but I
> also know that they do not!)

> Switch this script to inform the user that they have no `.git/safe`
> directory but might like to make one.

Since suspenders may no longer mark projects safe by default, this
commit introduces the `git safe` command to do so.

[dotfiles]: https://github.com/thoughtbot/dotfiles/blob/af75a673b1d8465a1e8c55c33f4a79fe3f5dc3c7/zsh/configs/post/path.zsh#L9-L10
[#837]: https://github.com/thoughtbot/suspenders/pull/837