### PR TITLE
Use ASDF for version managment

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ configuration:
 [Ruby](https://www.ruby-lang.org/en/) configuration:
 
 * Add trusted binstubs to the `PATH`.
-* Load the ASDF version manager, falling back to rbenv if not installed.
+* Load the ASDF version manager.
 
 Shell aliases and scripts:
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ configuration:
 [Ruby](https://www.ruby-lang.org/en/) configuration:
 
 * Add trusted binstubs to the `PATH`.
-* Load rbenv into the shell, adding shims onto our `PATH`.
+* Load the ASDF version manager, falling back to rbenv if not installed.
 
 Shell aliases and scripts:
 

--- a/zsh/configs/post/path.zsh
+++ b/zsh/configs/post/path.zsh
@@ -5,6 +5,14 @@ PATH="$HOME/.bin:/usr/local/sbin:$PATH"
 if [ -d "$HOME/.asdf" ]; then
   . $HOME/.asdf/asdf.sh
 elif command -v rbenv >/dev/null; then
+  if [ -z $SILENCE_RBENV_DEPRECATION ]; then
+    echo "The thoughtbot dotfiles have deprecated the use of rbenv in favor"\
+         "of asdf (https://github.com/asdf-vm/asdf) and will be removed on or"\
+         "after December 8, 2017.  Migrate to asdf or export"\
+         "SILENCE_RBENV_DEPRECATION=1 in your local dotfiles to silence this"\
+         "deprecation."
+  fi
+
   eval "$(rbenv init - --no-rehash)"
 fi
 

--- a/zsh/configs/post/path.zsh
+++ b/zsh/configs/post/path.zsh
@@ -1,8 +1,10 @@
 # ensure dotfiles bin directory is loaded first
 PATH="$HOME/.bin:/usr/local/sbin:$PATH"
 
-# load rbenv if available
-if command -v rbenv >/dev/null; then
+# load ASDF, falling back to rbenv if not available
+if [ -d "$HOME/.asdf" ]; then
+  . $HOME/.asdf/asdf.sh
+elif command -v rbenv >/dev/null; then
   eval "$(rbenv init - --no-rehash)"
 fi
 


### PR DESCRIPTION
ASDF has plugins for Ruby, Node, Elixir, Haskell, Scala, Go, etc.
Instead of finding and installing a new tool each time we have need for
a version manager in a new tools, we can use the same tool we already
know, adding a new plugin.

This change is the result of a successful [research card][1] and has a
corresponding change to [laptop][2].

[1]: https://trello.com/c/MVbfz8e5/676-asdf-for-tool-management
[2]: https://github.com/thoughtbot/laptop/pull/502