### PR TITLE
Replace Syntastic with ALE

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -44,6 +44,14 @@ augroup vimrcEx
   autocmd BufRead,BufNewFile Appraisals set filetype=ruby
   autocmd BufRead,BufNewFile *.md set filetype=markdown
   autocmd BufRead,BufNewFile .{jscs,jshint,eslint}rc set filetype=json
+
+  " ALE linting events
+  set updatetime=1000
+  let g:ale_lint_on_text_changed = 0
+  autocmd CursorHold * call ale#Lint()
+  autocmd CursorHoldI * call ale#Lint()
+  autocmd InsertEnter * call ale#Lint()
+  autocmd InsertLeave * call ale#Lint()
 augroup END
 
 " When the type of shell script is /bin/sh, assume a POSIX-compatible
@@ -134,11 +142,9 @@ nnoremap <C-k> <C-w>k
 nnoremap <C-h> <C-w>h
 nnoremap <C-l> <C-w>l
 
-" configure syntastic syntax checking to check on open as well as save
-let g:syntastic_check_on_open=1
-let g:syntastic_html_tidy_ignore_errors=[" proprietary attribute \"ng-"]
-let g:syntastic_eruby_ruby_quiet_messages =
-    \ {"regex": "possibly useless use of a variable in void context"}
+" Move between linting errors
+nnoremap ]r :ALENextWrap<CR>
+nnoremap [r :ALEPreviousWrap<CR>
 
 " Set spellfile to location that is guaranteed to exist, can be symlinked to
 " Dropbox or kept in Git and managed outside of thoughtbot/dotfiles using rcm.

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -43,7 +43,6 @@ Plug 'janko-m/vim-test'
 Plug 'kchmck/vim-coffee-script'
 Plug 'pangloss/vim-javascript'
 Plug 'pbrisbin/vim-mkdir'
-Plug 'scrooloose/syntastic'
 Plug 'slim-template/vim-slim'
 Plug 'tpope/vim-bundler'
 Plug 'tpope/vim-endwise'
@@ -57,6 +56,7 @@ Plug 'tpope/vim-rhubarb'
 Plug 'tpope/vim-surround'
 Plug 'vim-ruby/vim-ruby'
 Plug 'vim-scripts/tComment'
+Plug 'w0rp/ale'
 
 if filereadable(expand("~/.vimrc.bundles.local"))
   source ~/.vimrc.bundles.local


### PR DESCRIPTION
ALE is an Asynchronous Linting Engine which works with Vim 8 and NeoVim
to lint your code "as you type". It does so without blocking the main
thread by using the asynchronous features of both of those Vim versions.

A number of us in Boston have been using ALE for some time now with
great success. The asynchronous nature means linting does not block
other interactions with Vim and it's been nice to get linting feedback
more often than buffer write.

Many of us find the "as-you-type" linting to be performant enough to
actually be a distraction, so this PR tones that down some. With this
configuration, ALE will lint on cursor hold durations of 1 second and
when leaving insert mode in addition to buffer write, buffer read, and
file type change.