### PR TITLE
Require Vim 8 or NeoVim

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -12,6 +12,8 @@ set incsearch     " do incremental searching
 set laststatus=2  " Always display the status line
 set autowrite     " Automatically :write before running commands
 
+let g:has_async = v:version >= 800 || has('nvim')
+
 " Switch syntax highlighting on, when the terminal has colors
 " Also switch on highlighting the last used search pattern.
 if (&t_Co > 2 || has("gui_running")) && !exists("syntax_on")
@@ -46,7 +48,7 @@ augroup vimrcEx
   autocmd BufRead,BufNewFile .{jscs,jshint,eslint}rc set filetype=json
 
   " ALE linting events
-  if v:version >= 800
+  if g:has_async
     set updatetime=1000
     let g:ale_lint_on_text_changed = 0
     autocmd CursorHold * call ale#Lint()
@@ -55,7 +57,7 @@ augroup vimrcEx
     autocmd InsertLeave * call ale#Lint()
   else
     echoerr "The thoughtbot dotfiles require NeoVim or Vim 8"
-  end
+  endif
 augroup END
 
 " When the type of shell script is /bin/sh, assume a POSIX-compatible

--- a/vimrc
+++ b/vimrc
@@ -18,10 +18,6 @@ if (&t_Co > 2 || has("gui_running")) && !exists("syntax_on")
   syntax on
 endif
 
-if v:version < 800
-  echoerr "The thoughtbot dotfiles require NeoVim or Vim 8"
-endif
-
 if filereadable(expand("~/.vimrc.bundles"))
   source ~/.vimrc.bundles
 endif
@@ -57,6 +53,8 @@ augroup vimrcEx
     autocmd CursorHoldI * call ale#Lint()
     autocmd InsertEnter * call ale#Lint()
     autocmd InsertLeave * call ale#Lint()
+  else
+    echoerr "The thoughtbot dotfiles require NeoVim or Vim 8"
   end
 augroup END
 

--- a/vimrc
+++ b/vimrc
@@ -18,6 +18,10 @@ if (&t_Co > 2 || has("gui_running")) && !exists("syntax_on")
   syntax on
 endif
 
+if v:version < 800
+  echoerr "The thoughtbot dotfiles require NeoVim or Vim 8"
+endif
+
 if filereadable(expand("~/.vimrc.bundles"))
   source ~/.vimrc.bundles
 endif
@@ -46,12 +50,14 @@ augroup vimrcEx
   autocmd BufRead,BufNewFile .{jscs,jshint,eslint}rc set filetype=json
 
   " ALE linting events
-  set updatetime=1000
-  let g:ale_lint_on_text_changed = 0
-  autocmd CursorHold * call ale#Lint()
-  autocmd CursorHoldI * call ale#Lint()
-  autocmd InsertEnter * call ale#Lint()
-  autocmd InsertLeave * call ale#Lint()
+  if v:version >= 800
+    set updatetime=1000
+    let g:ale_lint_on_text_changed = 0
+    autocmd CursorHold * call ale#Lint()
+    autocmd CursorHoldI * call ale#Lint()
+    autocmd InsertEnter * call ale#Lint()
+    autocmd InsertLeave * call ale#Lint()
+  end
 augroup END
 
 " When the type of shell script is /bin/sh, assume a POSIX-compatible

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -57,7 +57,7 @@ Plug 'tpope/vim-surround'
 Plug 'vim-ruby/vim-ruby'
 Plug 'vim-scripts/tComment'
 
-if v:version >= 800
+if g:has_async
   Plug 'w0rp/ale'
 endif
 

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -56,7 +56,10 @@ Plug 'tpope/vim-rhubarb'
 Plug 'tpope/vim-surround'
 Plug 'vim-ruby/vim-ruby'
 Plug 'vim-scripts/tComment'
-Plug 'w0rp/ale'
+
+if v:version >= 800
+  Plug 'w0rp/ale'
+endif
 
 if filereadable(expand("~/.vimrc.bundles.local"))
   source ~/.vimrc.bundles.local


### PR DESCRIPTION
Now that we're using `ALE`, we're making use of the async features
available in Vim8 and NeoVim. If you try to use these dotfiles on Vim 7,
you'll get a host of errors from ALE.

This change does two things:

1. It writes an error when starting in an unsupported vim version.
2. It skips loading ALE in those versions.

The thinking behind the second change is to leave vim in a more usable
state with minimal annoyance after the initial error.