### PR TITLE
has_async is undefined when running rcup

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -57,6 +57,8 @@ Plug 'tpope/vim-surround'
 Plug 'vim-ruby/vim-ruby'
 Plug 'vim-scripts/tComment'
 
+let g:has_async = v:version >= 800 || has('nvim')
+
 if g:has_async
   Plug 'w0rp/ale'
 endif


### PR DESCRIPTION
@derekprior I pulled down master today and when I ran `rcup` it complained that `has_async` was undefined in `vimrc.bundles`

I simply copied the code that existed in `vimrc`

Is there a better way to do this that doesn't duplicate code?