### PR TITLE
Move definition of `has_async`

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -12,8 +12,6 @@ set incsearch     " do incremental searching
 set laststatus=2  " Always display the status line
 set autowrite     " Automatically :write before running commands
 
-let g:has_async = v:version >= 800 || has('nvim')
-
 " Switch syntax highlighting on, when the terminal has colors
 " Also switch on highlighting the last used search pattern.
 if (&t_Co > 2 || has("gui_running")) && !exists("syntax_on")

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -32,6 +32,8 @@ endfunction
 com! -nargs=+  -bar Plugin call VundleToPlug("Plugin", <args>)
 com! -nargs=+  -bar Bundle call VundleToPlug("Bundle", <args>)
 
+let g:has_async = v:version >= 800 || has('nvim')
+
 call plug#begin('~/.vim/bundle')
 
 " Define bundles via Github repos


### PR DESCRIPTION
We have an rcm `post-up` hook that installs plugins after running
`rcup`. It does this by directly loading the `.vimrc.bundles` file,
which means our regular `.vimrc` file is not sourced. This lead to
`has_async` being undefined.

By moving the definition into the `vimrc.bundles` we ensure it's
available when that `post-up` hook runs. It remains available when
needed in `vimrc` because we use it there *after* sourcing the bundles.