### PR TITLE
Fix Personal Customization Path

### DIFF
--- a/aliases
+++ b/aliases
@@ -16,4 +16,4 @@ alias s="rspec"
 alias path='echo $PATH | tr -s ":" "\n"'
 
 # Include custom aliases
-[[ -f ~/.aliases.local ]] && source ~/.aliases.local
+[[ -f ~/dotfiles-local/aliases.local ]] && source ~/dotfiles-local/aliases.local

--- a/git_template/hooks/post-checkout
+++ b/git_template/hooks/post-checkout
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-local_hook="$HOME"/.git_template.local/hooks/post-checkout
+local_hook="$HOME"/dotfiles-local/git_template.local/hooks/post-checkout
 [ -f "$local_hook" ] && . "$local_hook"
 
 .git/hooks/ctags >/dev/null 2>&1 &

--- a/git_template/hooks/post-commit
+++ b/git_template/hooks/post-commit
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-local_hook="$HOME"/.git_template.local/hooks/post-commit
+local_hook="$HOME"/dotfiles-local/git_template.local/hooks/post-commit
 [ -f "$local_hook" ] && . "$local_hook"
 
 .git/hooks/ctags >/dev/null 2>&1 &

--- a/git_template/hooks/post-merge
+++ b/git_template/hooks/post-merge
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-local_hook="$HOME"/.git_template.local/hooks/post-merge
+local_hook="$HOME"/dotfiles-local/git_template.local/hooks/post-merge
 [ -f "$local_hook" ] && . "$local_hook"
 
 .git/hooks/ctags >/dev/null 2>&1 &

--- a/git_template/hooks/pre-commit
+++ b/git_template/hooks/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-local_hook="$HOME"/.git_template.local/hooks/pre-commit
+local_hook="$HOME"/dotfiles-local/git_template.local/hooks/pre-commit
 
 if [ -f "$local_hook" ]; then
   . "$local_hook"

--- a/git_template/hooks/pre-push
+++ b/git_template/hooks/pre-push
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-local_hook="$HOME"/.git_template.local/hooks/pre-push
+local_hook="$HOME"/dotfiles-local/git_template.local/hooks/pre-push
 
 if [ -f "$local_hook" ]; then
   . "$local_hook"

--- a/git_template/hooks/prepare-commit-msg
+++ b/git_template/hooks/prepare-commit-msg
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-local_hook="$HOME"/.git_template.local/hooks/prepare-commit-msg
+local_hook="$HOME"/dotfiles-local/git_template.local/hooks/prepare-commit-msg
 
 if [ -f "$local_hook" ]; then
   . "$local_hook"

--- a/gitconfig
+++ b/gitconfig
@@ -24,4 +24,4 @@
 [rebase]
   autosquash = true
 [include]
-  path = ~/.gitconfig.local
+  path = ~/dotfiles-local/gitconfig.local

--- a/psqlrc
+++ b/psqlrc
@@ -24,5 +24,5 @@
 
 -- psql can't check for a file's existence, so we'll provide an empty local
 -- file that users can override with their custom dotfiles. To set your own
--- personal settings, place your own file in ~/.psqlrc.local
-\i ~/.psqlrc.local
+-- personal settings, place your own file in ~/dotfiles-local/psqlrc.local
+\i ~/dotfiles-local/psqlrc.local

--- a/tmux.conf
+++ b/tmux.conf
@@ -39,4 +39,4 @@ bind-key C-s send-prefix -2
 unbind-key C-z
 
 # Local config
-if-shell "[ -f ~/.tmux.conf.local ]" 'source ~/.tmux.conf.local'
+if-shell "[ -f ~/dotfiles-local/tmux.conf.local ]" 'source ~/dotfiles-local/tmux.conf.local'

--- a/vimrc
+++ b/vimrc
@@ -161,6 +161,6 @@ set complete+=kspell
 set diffopt+=vertical
 
 " Local config
-if filereadable($HOME . "/.vimrc.local")
-  source ~/.vimrc.local
+if filereadable($HOME . "/dotfiles-local/vimrc.local")
+  source ~/dotfiles-local/vimrc.local
 endif

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -63,8 +63,8 @@ if g:has_async
   Plug 'w0rp/ale'
 endif
 
-if filereadable(expand("~/.vimrc.bundles.local"))
-  source ~/.vimrc.bundles.local
+if filereadable(expand("~/dotfiles-local/vimrc.bundles.local"))
+  source ~/dotfiles-local/vimrc.bundles.local
 endif
 
 call plug#end()

--- a/zshenv
+++ b/zshenv
@@ -1,7 +1,7 @@
 local _old_path="$PATH"
 
 # Local config
-[[ -f ~/.zshenv.local ]] && source ~/.zshenv.local
+[[ -f ~/dotfiles-local/.zshenv.local ]] && source ~/dotfiles-local/.zshenv.local
 
 if [[ $PATH != $_old_path ]]; then
   # `colors` isn't initialized yet, so define a few manually
@@ -17,9 +17,9 @@ if [[ $PATH != $_old_path ]]; then
   fi
 
   cat <<MSG >&2
-${fg[red]}Warning:${reset_color} your \`~/.zshenv.local' configuration seems to edit PATH entries.
-Please move that configuration to \`.zshrc.local' like so:
-  ${fg_bold[white]}cat ~/.zshenv.local >> ~/.zshrc.local && rm ~/.zshenv.local${reset_color}
+${fg[red]}Warning:${reset_color} your \`~/dotfiles-local/zshenv.local' configuration seems to edit PATH entries.
+Please move that configuration to \`~/dotfiles-local/zshrc.local' like so:
+  ${fg_bold[white]}cat ~/dotfiles-local/zshenv.local >> ~/dotfiles-local/zshrc.local && rm ~/dotfiles-local/zshenv.local${reset_color}
 
 (called from ${(%):-%N:%i})
 

--- a/zshrc
+++ b/zshrc
@@ -40,7 +40,7 @@ _load_settings() {
 _load_settings "$HOME/.zsh/configs"
 
 # Local config
-[[ -f ~/.zshrc.local ]] && source ~/.zshrc.local
+[[ -f ~/dotfiles-local/zshrc.local ]] && source ~/dotfiles-local/zshrc.local
 
 # aliases
 [[ -f ~/.aliases ]] && source ~/.aliases


### PR DESCRIPTION
There are inconsistencies between the README and the personal
customization path. This commit is to fix the path to personal
customizations file as any customizations placed in `~/dotfiles-local`
will not be loaded correctly.

Lets take `zshrc.local` as an example. In README, it is stated that customizations have to be placed in `~/dotfiles-local/zshrc.local`. However, in the `zshrc`, the local config path points to `~/.zshrc.local` without the `/dotfiles-local` directory and has a `dot` file extension.