### PR TITLE
Add a specific "Update" section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,17 @@ configuration options:
 * Please configure the `rcrc` file if you'd like to make personal
   overrides in a different directory
 
-You can safely run `rcup` multiple times to update:
+
+Update
+------
+
+From time to time you should pull down any updates to these dotfiles, and run
 
     rcup
 
-You should run `rcup` after pulling a new version of the repository to symlink
-any new files in the repository.
+to link any new files and install new vim plugins. **Note** You _must_ run
+`rcup` after pulling to ensure that all files in plugins are properly installed,
+but you can safely run `rcup` multiple times so update early and update often!
 
 Make your own customizations
 ----------------------------


### PR DESCRIPTION
Thanks to rcm and the `post-up` hook file, the dotfiles do a great job
of keeping things up to date.

This change adds a bit of detail and specificity to the README around
updating, specifically clarifying the need to run `rcup` after pulling
to link new files and install new vim plugins.