### PR TITLE
Filter commented lines out of .env in envup

### DIFF
--- a/zsh/functions/envup
+++ b/zsh/functions/envup
@@ -2,7 +2,7 @@
 
 function envup() {
   if [ -f .env ]; then
-    export $(cat .env)
+    export $(sed '/^ *#/ d' .env)
   else
     echo 'No .env file found' 1>&2
     return 1


### PR DESCRIPTION
This allows one to comment out lines in a `.env` file using `#` and not have them exported when running `envup`

Without this if your `.env` file is something like

```
SYNC_URL=localhost:4000
# SYNC_URL=production.sync.com
```
and you run `envup`, the 2nd assignment will be exported!

