### PR TITLE
Update references from ~/.<UTIL>.local to ~/dotfiles-local/<UTIL>.local

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Your `~/dotfiles-local/vimrc.local` might look like this:
 
 If you don't wish to install a vim plugin from the default set of vim plugins in
 `.vimrc.bundles`, you can ignore the plugin by calling it out with `UnPlug` in
-your `~/.vimrc.bundles.local`.
+your `~/dotfiles-local/vimrc.bundles.local`.
 
     " Don't install vim-scripts/tComment
     UnPlug 'tComment'

--- a/aliases
+++ b/aliases
@@ -16,4 +16,4 @@ alias s="rspec"
 alias path='echo $PATH | tr -s ":" "\n"'
 
 # Include custom aliases
-[[ -f ~/.aliases.local ]] && source ~/.aliases.local
+[[ -f ~/dotfiles-local/aliases.local ]] && source ~/dotfiles-local/aliases.local

--- a/gitconfig
+++ b/gitconfig
@@ -24,4 +24,4 @@
 [rebase]
   autosquash = true
 [include]
-  path = ~/.gitconfig.local
+  path = ~/dotfiles-local/gitconfig.local

--- a/psqlrc
+++ b/psqlrc
@@ -24,5 +24,5 @@
 
 -- psql can't check for a file's existence, so we'll provide an empty local
 -- file that users can override with their custom dotfiles. To set your own
--- personal settings, place your own file in ~/.psqlrc.local
-\i ~/.psqlrc.local
+-- personal settings, place your own file in ~/dotfiles-local/psqlrc.local
+\i ~/dotfiles-local/psqlrc.local

--- a/tmux.conf
+++ b/tmux.conf
@@ -39,4 +39,4 @@ bind-key C-s send-prefix -2
 unbind-key C-z
 
 # Local config
-if-shell "[ -f ~/.tmux.conf.local ]" 'source ~/.tmux.conf.local'
+if-shell "[ -f ~/dotfiles-local/tmux.conf.local ]" 'source ~/dotfiles-local/tmux.conf.local'

--- a/vimrc
+++ b/vimrc
@@ -161,6 +161,6 @@ set complete+=kspell
 set diffopt+=vertical
 
 " Local config
-if filereadable($HOME . "/.vimrc.local")
-  source ~/.vimrc.local
+if filereadable($HOME . "/dotfiles-local/vimrc.local")
+  source ~/dotfiles-local/vimrc.local
 endif

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -63,8 +63,8 @@ if g:has_async
   Plug 'w0rp/ale'
 endif
 
-if filereadable(expand("~/.vimrc.bundles.local"))
-  source ~/.vimrc.bundles.local
+if filereadable(expand("~/dotfiles-local/vimrc.bundles.local"))
+  source ~/dotfiles-local/vimrc.bundles.local
 endif
 
 call plug#end()

--- a/zshenv
+++ b/zshenv
@@ -1,7 +1,7 @@
 local _old_path="$PATH"
 
 # Local config
-[[ -f ~/.zshenv.local ]] && source ~/.zshenv.local
+[[ -f ~/dotfiles-local/zshenv.local ]] && source ~/dotfiles-local/zshenv.local
 
 if [[ $PATH != $_old_path ]]; then
   # `colors` isn't initialized yet, so define a few manually
@@ -17,9 +17,9 @@ if [[ $PATH != $_old_path ]]; then
   fi
 
   cat <<MSG >&2
-${fg[red]}Warning:${reset_color} your \`~/.zshenv.local' configuration seems to edit PATH entries.
-Please move that configuration to \`.zshrc.local' like so:
-  ${fg_bold[white]}cat ~/.zshenv.local >> ~/.zshrc.local && rm ~/.zshenv.local${reset_color}
+${fg[red]}Warning:${reset_color} your \`~/dotfiles-local/zshenv.local' configuration seems to edit PATH entries.
+Please move that configuration to \`~/dotfiles-local/zshrc.local' like so:
+  ${fg_bold[white]}cat ~/dotfiles-local/zshenv.local >> ~/dotfiles-local/zshrc.local && rm ~/dotfiles-local/zshenv.local${reset_color}
 
 (called from ${(%):-%N:%i})
 

--- a/zshrc
+++ b/zshrc
@@ -42,7 +42,7 @@ _load_settings() {
 _load_settings "$HOME/.zsh/configs"
 
 # Local config
-[[ -f ~/.zshrc.local ]] && source ~/.zshrc.local
+[[ -f ~/dotfiles-local/zshrc.local ]] && source ~/dotfiles-local/zshrc.local
 
 # aliases
 [[ -f ~/.aliases ]] && source ~/.aliases


### PR DESCRIPTION
Based on [this commit](https://github.com/thoughtbot/dotfiles/commit/09d54d448c0d70f2e404e7610cac1d5314f76593?diff=split), it looks like local conf files have moved from (e.g.) `~/.zshrc.local` => `~/dotfiles-local/zshrc.local`.

Unless these references were left in for backwards compatibility, they should reference the new structure. 