### PR TITLE
Add instruction to overwrite default configurations via dotfiles-local

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,7 @@ Your `~/dotfiles-local/vimrc.local` might look like this:
     highlight NonText guibg=#060606
     highlight Folded  guibg=#0A0A0A guifg=#9090D0
 
-If you want to use your own `.vimrc` or `.vimrc.bundles` file. You can create your own `vimrc` or `vimrc.bundles` in 
-your `~/dotfiles-local` folder and run `rcup`. Since `rcup` gives precedence to personal overrides, it will overwrite
-the files being symlinked to the ones you have in your `~/dotfiles-local`.
+if you want your customizations to overwrite rather than add to the files in this repository, you can give them the name of the original file, and rcm will use your file in dotfiles-local over the version here.
 
 If you don't wish to install a vim plugin from the default set of vim plugins in
 `.vimrc.bundles`, you can ignore the plugin by calling it out with `UnPlug` in

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Your `~/dotfiles-local/vimrc.local` might look like this:
     highlight NonText guibg=#060606
     highlight Folded  guibg=#0A0A0A guifg=#9090D0
 
+If you want to use your own `.vimrc` or `.vimrc.bundles` file. You can create your own `vimrc` or `vimrc.bundles` in 
+your `~/dotfiles-local` folder and run `rcup`. Since `rcup` gives precedence to personal overrides, it will overwrite
+the files being symlinked to the ones you have in your `~/dotfiles-local`.
+
 If you don't wish to install a vim plugin from the default set of vim plugins in
 `.vimrc.bundles`, you can ignore the plugin by calling it out with `UnPlug` in
 your `~/.vimrc.bundles.local`.


### PR DESCRIPTION
It's not obvious currently that you can overwrite anything that is being symlinked in `dotfiles` folder with the files you have in `dotfiles-local` as long as you name it the same. So in my case, I wanted to maintain my own vim configuration but I don't want to lose the other configuration that is already set  in place. 