### PR TITLE
Fixup g function to start with function keywork (like our other functions)

### DIFF
--- a/zsh/functions/g
+++ b/zsh/functions/g
@@ -1,6 +1,6 @@
 # No arguments: `git status`
 # With arguments: acts like `git`
-g() {
+function g() {
   if [[ $# -gt 0 ]]; then
     git "$@"
   else


### PR DESCRIPTION
I was getting the following error when manually sourcing ~/.zshrc:

    /Users/jeckhart/.zsh/functions/g:3: defining function based on alias `g'
    /Users/jeckhart/.zsh/functions/g:3: parse error near `()'

This cleans up the g function definition.