### PR TITLE
Exclude ASDF project version file from Git

### DIFF
--- a/git_template/info/exclude
+++ b/git_template/info/exclude
@@ -4,3 +4,5 @@
 # exclude patterns (uncomment them if you want to use them):
 # *.[oa]
 # *~
+
+.tool-versions


### PR DESCRIPTION
ASDF respects tool-specific version files through the
`legacy_versions` configuration parameter. This change prevents a
developer's settings from creeping into the repository.