### PR TITLE
Add ALE fix for Rails ERB templates

### DIFF
--- a/vim/plugin/ale.vim
+++ b/vim/plugin/ale.vim
@@ -1,0 +1,13 @@
+call ale#linter#Define('eruby', {
+  \   'name': 'erubylint',
+  \   'executable': 'erb',
+  \   'output_stream': 'stderr',
+  \   'command': "ruby -rerb -e \"puts ERB.new(File.read(%t, encoding: 'BINARY').gsub('<%=','<%'), nil, '-').src\" | ruby -c",
+  \   'callback': 'ale#handlers#ruby#HandleSyntaxErrors',
+  \})
+
+if !exists('g:ale_linters')
+  let g:ale_linters = {}
+endif
+
+let g:ale_linters['eruby'] = ['erubylint']


### PR DESCRIPTION
See this discussion on the related ALE issue:
https://github.com/w0rp/ale/issues/580#issuecomment-337676607

This change sets up ALE to use a custom linter for Rails ERB templates to
accommodate the syntax. Without the change, the `erb` linter raises
errors on templates within a Rails application (including blank files).

We define the `g:ale_linters` dictionary conditionally in case the user
has already defined it elsewhere. Users with existing ALE linter
customizations may need to change their definition so that they don't
wipe this setting out.

Close #556.