### PR TITLE
Use long options for when calling `ag` for CtrlP plugin

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -80,7 +80,7 @@ if executable('ag')
   set grepprg=ag\ --nogroup\ --nocolor
 
   " Use ag in CtrlP for listing files. Lightning fast and respects .gitignore
-  let g:ctrlp_user_command = 'ag -Q -l --nocolor --hidden -g "" %s'
+  let g:ctrlp_user_command = 'ag --literal --files-with-matches --nocolor --hidden --filename-pattern "" %s'
 
   " ag is fast enough that CtrlP doesn't need to cache
   let g:ctrlp_use_caching = 0


### PR DESCRIPTION
I propose to change this because:

* It is more self-documenting to use the long options.
* It uses a consistent style, rather than mixing short and long styles.