### PR TITLE
Change zsh ctrl-n keybinding to be opposite of ctrl-p

### DIFF
--- a/zsh/configs/keybindings.zsh
+++ b/zsh/configs/keybindings.zsh
@@ -11,7 +11,8 @@ bindkey "^E" end-of-line
 bindkey "^K" kill-line
 bindkey "^R" history-incremental-search-backward
 bindkey "^P" history-search-backward
+bindkey "^N" history-search-forward
 bindkey "^Y" accept-and-hold
-bindkey "^N" insert-last-word
+bindkey "^[." insert-last-word
 bindkey "^Q" push-line-or-edit
 bindkey -s "^T" "^[Isudo ^[A" # "t" for "toughguy"


### PR DESCRIPTION
Everywhere where ctrl-p is "previous" I expect ctrl-n to be "next".

Not sure what to do about the `insert-last-word` keybinding -- OK to remove? Map it to something else?