### PR TITLE
Use -g instead of --filename-pattern as Ag argument

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -80,7 +80,7 @@ if executable('ag')
   set grepprg=ag\ --nogroup\ --nocolor
 
   " Use ag in CtrlP for listing files. Lightning fast and respects .gitignore
-  let g:ctrlp_user_command = 'ag --literal --files-with-matches --nocolor --hidden --filename-pattern "" %s'
+  let g:ctrlp_user_command = 'ag --literal --files-with-matches --nocolor --hidden -g "" %s'
 
   " ag is fast enough that CtrlP doesn't need to cache
   let g:ctrlp_use_caching = 0


### PR DESCRIPTION
While I love how explicit `--filename-pattern` is, the option is unavailable in Linux build, or at least Ubuntu build. 
When running CtrlP on Linux, it will show ag help instead of file list in a directory
![ctrlp2](https://user-images.githubusercontent.com/1308495/33078344-f5e6971a-cf04-11e7-8587-1eaaad9464b2.png)

This is because the option is available in Mac OS build. I checked by issuing `ag` command on both of my laptops and found out that it Ag did not alias `--filename-pattern` on Ubuntu machine.

This change should make Ag and CtrlP work together more universally.

_Fixed_
![ctrlp fixed](https://user-images.githubusercontent.com/1308495/33078501-73d46fc6-cf05-11e7-8bed-bf35943d6f23.png)
