### PR TITLE
zsh: Allow prompt to be overridden

### DIFF
--- a/zsh/configs/prompt.zsh
+++ b/zsh/configs/prompt.zsh
@@ -5,5 +5,10 @@ git_prompt_info() {
     echo " %{$fg_bold[green]%}$current_branch%{$reset_color%}"
   fi
 }
+
 setopt promptsubst
-PS1='${SSH_CONNECTION+"%{$fg_bold[green]%}%n@%m:"}%{$fg_bold[blue]%}%c%{$reset_color%}$(git_prompt_info) %# '
+
+# Allow exported PS1 variable to override default prompt.
+if ! env | grep -q '^PS1='; then
+  PS1='${SSH_CONNECTION+"%{$fg_bold[green]%}%n@%m:"}%{$fg_bold[blue]%}%c%{$reset_color%}$(git_prompt_info) %# '
+fi


### PR DESCRIPTION
`zsh/configs/prompt.zsh` sets up the dotfile's custom prompt. It
currently does so in a way which prevents overriding the prompt for
specific invocations of zsh.

I noticed this because I've got a helper script for getting a shell
fully configured to work with the AWS CLI that ends with
`PS1='[aws] ' exec "$SHELL"` to distinguish the shell from other
sessions. With a vanilla zsh (and bash) setup, this correctly sets the
prompt on the new shell.

Here's a minimal demonstration with vanilla zsh:

```
bernerdscha-ltm% echo $PS1
%m%#
bernerdscha-ltm% PS1="hi> " exec zsh
hi>
```

And with dotfiles:

```
dotfiles bs-override-ps1 % echo $PS1
${SSH_CONNECTION+"%{$fg_bold[green]%}%n@%m"}%{$fg_bold[blue]%}%c%{$reset_color%}$(git_prompt_info) %#
dotfiles bs-override-ps1 % PS1="hi> " exec zsh
dotfiles bs-override-ps1 %
```

This PR updates prompt.zsh to only update the prompt if there's not an
existing exported PS1 variable. The export check is relevant because in
the default case where PS1 is not explicitly set  by the user it will
have already been set (but not exported) by the default zsh configs.