### PR TITLE
merge-branch: exit 1 if origin and local differ

### DIFF
--- a/bin/git-merge-branch
+++ b/bin/git-merge-branch
@@ -2,5 +2,13 @@
 
 set -e
 
+git fetch origin
+line_count=$(git diff origin/master..master | wc -l)
+
+if [ $line_count -gt 0 ]; then
+  printf "failed: master is not up to date with origin/master\n"
+  exit 1
+fi
+
 git checkout master
 git merge "@{-1}"


### PR DESCRIPTION
This change prevents chained commands from continuing execution if the
`git merge` is operation would be unsuccessful such as a common
operation when a feature branch is ready to be merged and pushed:

```
git merge-branch && git push origin
```

If the origin/master and the local master have any difference, we return
status 1 and stop execution rather then emit a false success.

h/t: @croaky

Fix #563.