### PR TITLE
Use consistent syntax for tmux mappings

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -3,10 +3,10 @@ set -g default-terminal 'screen-256color'
 
 # act like vim
 setw -g mode-keys vi
-bind h select-pane -L
-bind j select-pane -D
-bind k select-pane -U
-bind l select-pane -R
+bind-key h select-pane -L
+bind-key j select-pane -D
+bind-key k select-pane -U
+bind-key l select-pane -R
 bind-key -r C-h select-window -t :-
 bind-key -r C-l select-window -t :+
 


### PR DESCRIPTION
`bind` is effectively an alias for `bind-key`:

See https://superuser.com/questions/581939/on-tmux-what-is-the-difference-between-bind-and-bind-key

(The file current contains an equal count of `bind` vs `bind-key`, so I could have changed the others to `bind`, but I think it's better to use the full command name).