### PR TITLE
git: Use `zebra` for moved line colors

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -25,3 +25,5 @@
   autosquash = true
 [include]
   path = ~/.gitconfig.local
+[diff]
+  colorMoved = zebra


### PR DESCRIPTION
This change uses a git 2.15 feature to change the diff colors for lines
that have been moved rather than added or deleted. It provides a cue to
readers that a line's content has not changed.

Adding this setting in gitconfig should not break earlier git. (Tested
against 2.14 and the change had no effect.)

https://twitter.com/SmileyKeith/status/946789768506912773