### PR TITLE
Add co-author prompt to gitmessage template

### DIFF
--- a/gitmessage
+++ b/gitmessage
@@ -9,3 +9,8 @@
 # * Are there any side effects?
 #
 # Include a link to the ticket, if any.
+#
+# Add co-authors if you worked on this code with others:
+#
+# Co-authored-by: Full Name <email@example.com>
+# Co-authored-by: Full Name <email@example.com>


### PR DESCRIPTION
GitHub now supports trailers for co-authors. The syntax isn't the
easiest to remember, so having it as a prompt when commiting makes the
process easier.

More info: https://github.com/blog/2496-commit-together-with-co-authors