### PR TITLE
Improve successive startup time; fix conflict.

### DIFF
--- a/zsh/configs/post/completion.zsh
+++ b/zsh/configs/post/completion.zsh
@@ -1,6 +1,14 @@
 # load our own completion functions
 fpath=(~/.zsh/completion /usr/local/share/zsh/site-functions $fpath)
 
-# completion
-autoload -U compinit
-compinit
+# completion; use cache if updated within 24h
+autoload -Uz compinit
+if [[ -n $HOME/.zcompdump(#qN.mh+24) ]]; then
+  compinit -d $HOME/.zcompdump;
+else
+  compinit -C;
+fi;
+
+# disable zsh bundled function mtools command mcd
+# which causes a conflict.
+compdef -d mcd


### PR DESCRIPTION
- Don't update completion dump if it has been updated within 24hrs.
- Unload Completion for zsh bundled function mcd to prevent conflict. #594