### PR TITLE
Remove no-longer functional git-pr script

### DIFF
--- a/bin/git-pr
+++ b/bin/git-pr
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-set -e
-
-hub pull-request


### PR DESCRIPTION
The Github `hub` utilty has added a `pr` subcommand, which takes
precedence over `git-pr` in execution order, so this script is no longer
accessible with `git pr` or `hub pr`.