### PR TITLE
Change ctag git hook to use universal-ctags tag-relative syntax

### DIFF
--- a/git_template/hooks/ctags
+++ b/git_template/hooks/ctags
@@ -6,5 +6,5 @@ PATH="/usr/local/bin:$PATH"
 dir="$(git rev-parse --git-dir)"
 trap 'rm -f "$dir/$$.tags"' EXIT
 git ls-files | \
-  "${CTAGS:-ctags}" --tag-relative -L - -f"$dir/$$.tags" --languages=-javascript,sql
+  "${CTAGS:-ctags}" --tag-relative=yes -L - -f"$dir/$$.tags" --languages=-javascript,sql
 mv "$dir/$$.tags" "$dir/tags"


### PR DESCRIPTION
Change ctag git hook to use updated tag-relative syntax used by universal-ctags.