### PR TITLE
Fix vim ctag plugin

### DIFF
--- a/vim/plugin/ctags.vim
+++ b/vim/plugin/ctags.vim
@@ -3,10 +3,12 @@ let g:Tlist_Ctags_Cmd="ctags --exclude='*.js'"
 
 " Index ctags from any project, including those outside Rails
 function! ReindexCtags()
-  let l:ctags_hook = '$(git rev-parse --show-toplevel)/.git/hooks/ctags'
+  let l:ctags_hook_file = "$(git rev-parse --show-toplevel)/.git/hooks/ctags"
+  let l:ctags_hook_path = system("echo " . l:ctags_hook_file)
+  let l:ctags_hook_path = substitute(l:ctags_hook_path, '\n\+$', '', '')
 
-  if exists(l:ctags_hook)
-    exec '!'. l:ctags_hook
+  if filereadable(expand(l:ctags_hook_path))
+    exec '!'. l:ctags_hook_file
   else
     exec "!ctags -R ."
   endif


### PR DESCRIPTION
`exists(l:ctags_hook)` previously would never evaluate true even when the <git root>/.git/hooks/ctags file was present, which would cause two tags files to be generated if you manually tried to reindex the tags.