### PR TITLE
Use gitcommit syntax for Github pull requests

### DIFF
--- a/vim/ftplugin/gitcommit.vim
+++ b/vim/ftplugin/gitcommit.vim
@@ -1,3 +1,4 @@
 " Automatically wrap at 72 characters and spell check commit messages
+autocmd BufNewFile,BufRead PULLREQ_EDITMSG set syntax=gitcommit
 setlocal textwidth=72
 setlocal spell


### PR DESCRIPTION
This change leverages the existing `gitcommit` syntax rules to apply the
same formatting and highlighting settings to pull request messages when
they are edited from Vim.