### PR TITLE
Make _load_settings() more concise

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -9,31 +9,24 @@ _load_settings() {
   _dir="$1"
   if [ -d "$_dir" ]; then
     if [ -d "$_dir/pre" ]; then
-      for config in "$_dir"/pre/**/*(N-.); do
-        if [ ${config:e} = "zwc" ] ; then continue ; fi
+      for config in "$_dir"/pre/**/*~*.zwc(N-.); do
         . $config
       done
     fi
 
     for config in "$_dir"/**/*(N-.); do
       case "$config" in
-        "$_dir"/pre/*)
-          :
-          ;;
-        "$_dir"/post/*)
+        "$_dir"/(pre|post)/*|*.zwc)
           :
           ;;
         *)
-          if [[ -f $config && ${config:e} != "zwc" ]]; then
-            . $config
-          fi
+          . $config
           ;;
       esac
     done
 
     if [ -d "$_dir/post" ]; then
-      for config in "$_dir"/post/**/*(N-.); do
-        if [ ${config:e} = "zwc" ] ; then continue ; fi
+      for config in "$_dir"/post/**/*~*.zwc(N-.); do
         . $config
       done
     fi


### PR DESCRIPTION
- Use the `~` glob operator to exclude *.zwc insead of a separate test
  (requires `setopt extendedglob`).
- Exclude both `pre` and `post` in one case alternative.