### PR TITLE
Add git alias to prune old branches: git pob

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -11,6 +11,7 @@
   ci = commit -v
   co = checkout
   pf = push --force-with-lease
+  pob = "! f() { git fetch -p && for branch in `git branch -vv | grep ': gone]' | awk '{print $1}'`; do git branch -D $branch; done }; f"
   st = status
 [core]
   excludesfile = ~/.gitignore


### PR DESCRIPTION
`git pob` reaches out to the remote to find branches that have been deleted. If they have been deleted from the remote and you are tracking them, then those local branches will be deleted. This is completely safe on branches that you are tracking that have not been deleted. Local branches that you have not pushed up are also completely safe.