### PR TITLE
Replace ale#lint with ale#queue - ale#lint no longer supported

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -56,10 +56,10 @@ augroup ale
   if g:has_async
     set updatetime=1000
     let g:ale_lint_on_text_changed = 0
-    autocmd CursorHold * call ale#Lint()
-    autocmd CursorHoldI * call ale#Lint()
-    autocmd InsertEnter * call ale#Lint()
-    autocmd InsertLeave * call ale#Lint()
+    autocmd CursorHold * call ale#Queue(0)
+    autocmd CursorHoldI * call ale#Queue(0)
+    autocmd InsertEnter * call ale#Queue(0)
+    autocmd InsertLeave * call ale#Queue(0)
   else
     echoerr "The thoughtbot dotfiles require NeoVim or Vim 8"
   endif


### PR DESCRIPTION
Replaced the ale#lint function with ale#queue. Since ale#lint has been removed in favor of using ale#queue. See this [commit for reference](https://github.com/w0rp/ale/commit/2846e862178e9a16e078799c28aa9d9d4a2ea505#diff-767842d7a528439b87107a1c7807cddb). 