### PR TITLE
Allow easy disabling of all ALE configs

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -54,8 +54,9 @@ augroup ale
   autocmd!
 
   if g:has_async
-    set updatetime=1000
-    let g:ale_lint_on_text_changed = 0
+    autocmd VimEnter *
+      \ set updatetime=1000 |
+      \ let g:ale_lint_on_text_changed = 0
     autocmd CursorHold * call ale#Queue(0)
     autocmd CursorHoldI * call ale#Queue(0)
     autocmd InsertEnter * call ale#Queue(0)


### PR DESCRIPTION
Set `updatetime` option and `g:ale_lint_on_text_changed` variable in an Vim startup autocommand so that they won't be set when the user disables the `ale` augroup (with something like `silent! augroup! ale` or `augroup \ autocmd! \ augroup END`) in their local vimrc.

This allows users to use ALE with its default linting settings without needing to manually `unlet` the `updatetime` option and `g:ale_lint_on_text_changed` variable also.

Relavent issue/PRs:
- https://github.com/thoughtbot/dotfiles/issues/607
- https://github.com/thoughtbot/dotfiles/pull/608
- https://github.com/thoughtbot/dotfiles/pull/610/files