### PR TITLE
Add UTF-8 encoding to vimrc

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -1,3 +1,5 @@
+set encoding=utf-8
+
 " Leader
 let mapleader = " "
 


### PR DESCRIPTION
I started getting errors after a recent Vim upgrade because of this line:

`set list listchars=tab:»·,trail:·,nbsp:·`

Adding UTF-8 encoding fixes it.

```text
:h encoding

NOTE: For GTK+ 2 or later, it is highly recommended to set 'encoding'
        to "utf-8".  Although care has been taken to allow different values of
        'encoding', "utf-8" is the natural choice for the environment and
        avoids unnecessary conversion overhead.  "utf-8" has not been made
        the default to prevent different behavior of the GUI and terminal
        versions, and to avoid changing the encoding of newly created files
        without your knowledge (in case 'fileencodings' is empty).
```