### PR TITLE
Use rg if it's present in bin/replace

### DIFF
--- a/README-ES.md
+++ b/README-ES.md
@@ -124,7 +124,7 @@ Para extender tus `git` hooks, crea scripts ejecutables en
 Tu `~/dotfiles-local/zshrc.local` tal vez se vea así:
 
     # load pyenv if available
-    if which pyenv &>/dev/null ; then
+    if command -v pyenv &>/dev/null ; then
       eval "$(pyenv init -)"
     fi
 

--- a/bin/replace
+++ b/bin/replace
@@ -9,7 +9,7 @@ shift
 replace_with="$1"
 shift
 
-if which rg &>/dev/null ; then
+if command -v rg &>/dev/null ; then
   items=$(rg -l --color never "$find_this" "$@")
 else
   items=$(ag -l --nocolor "$find_this" "$@")

--- a/bin/replace
+++ b/bin/replace
@@ -9,7 +9,12 @@ shift
 replace_with="$1"
 shift
 
-items=$(ag -l --nocolor "$find_this" "$@")
+if which rg &>/dev/null ; then
+  items=$(rg -l --color never "$find_this" "$@")
+else
+  items=$(ag -l --nocolor "$find_this" "$@")
+fi
+
 temp="${TMPDIR:-/tmp}/replace_temp_file.$$"
 IFS=$'\n'
 for item in $items; do


### PR DESCRIPTION
👋 I like this `bin/replace` script, but I've recently switched from `ag` to [ripgrep](https://github.com/BurntSushi/ripgrep). This checks for the presence of `rg` and uses it in `bin/replace`, passing the correct parameter to disable colors.