### PR TITLE
Add scriptencoding utf-8 to vimrc

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -1,3 +1,5 @@
+:scriptencoding utf-8
+
 " Leader
 let mapleader = " "
 


### PR DESCRIPTION
vim 8.1 patches 1-550 displays the following message every time it is opened:
E474: Invalid argument: listchars=tab:»\ ,trail:·,extends:�~@�,precedes:�~@�,nbsp:&,eol:¬

Reference: https://github.com/vim/vim/issues/3668#issuecomment-444836976