### PR TITLE
Clarify ctags mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ What's in it?
 * Syntax highlighting for Markdown, HTML, JavaScript, Ruby, Go, Elixir, more.
 * Use [Ag](https://github.com/ggreer/the_silver_searcher) instead of Grep when
   available.
-* Map `<leader>ct` to re-index [Exuberant Ctags](http://ctags.sourceforge.net/).
+* Map `<leader>ct` to re-index ctags.
 * Use [vim-mkdir](https://github.com/pbrisbin/vim-mkdir) for automatically
   creating non-existing directories before writing the buffer.
 * Use [vim-plug](https://github.com/junegunn/vim-plug) to manage plugins.


### PR DESCRIPTION
`vim/plugin/ctags.vim` shells out to ctags, but this could be Universal
Ctags (see #605).