### PR TITLE
README: Mention excluded README-ES

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This command will create symlinks for config files in your home directory.
 Setting the `RCRC` environment variable tells `rcup` to use standard
 configuration options:
 
-* Exclude the `README.md` and `LICENSE` files, which are part of
+* Exclude the `README.md`, `README-ES.md` and `LICENSE` files, which are part of
   the `dotfiles` repository but do not need to be symlinked in.
 * Give precedence to personal overrides which by default are placed in
   `~/dotfiles-local`


### PR DESCRIPTION
Mention README-ES.md in section of excludes, which is already mentioned in the spanish version of the README (README-ES.md).