### PR TITLE
has-session - only exact matches

### DIFF
--- a/bin/tat
+++ b/bin/tat
@@ -10,7 +10,7 @@ not_in_tmux() {
 }
 
 session_exists() {
-  tmux has-session -t "$session_name"
+  tmux has-session -t "=$session_name"
 }
 
 create_detached_session() {


### PR DESCRIPTION
from man
>If the session name is prefixed with an ‘=’, only an exact match is accepted (so ‘=mysess’ will only match exactly ‘mysess’, not ‘mysession’).