### PR TITLE
Account for `asdf` being installed by Homebrew

### DIFF
--- a/zsh/configs/post/path.zsh
+++ b/zsh/configs/post/path.zsh
@@ -1,12 +1,16 @@
 # ensure dotfiles bin directory is loaded first
 PATH="$HOME/.bin:/usr/local/sbin:$PATH"
 
-# load ASDF, either from home dir or brew install
+# Try loading ASDF from the regular home dir location
 if [ -f "$HOME/.asdf/asdf.sh" ]; then
   . "$HOME/.asdf/asdf.sh"
+# It's not in the home dir, let's try the default Homebrew location
 elif [ -f "/usr/local/opt/asdf/asdf.sh" ]; then
   . "/usr/local/opt/asdf/asdf.sh"
-elif which brew >/dev/null && ASDF_PREFIX=$(brew --prefix asdf); then
+# Not there either! Last try, let's see if Homebrew can tell us where it is
+elif which brew >/dev/null &&
+  ASDF_PREFIX=$(brew --prefix asdf) &&
+  [ -f "$ASDF_PREFIX/asdf.sh" ]; then
   . "$ASDF_PREFIX/asdf.sh"
 fi
 

--- a/zsh/configs/post/path.zsh
+++ b/zsh/configs/post/path.zsh
@@ -1,9 +1,11 @@
 # ensure dotfiles bin directory is loaded first
 PATH="$HOME/.bin:/usr/local/sbin:$PATH"
 
-# load ASDF, falling back to rbenv if not available
-if [ -d "$HOME/.asdf" ]; then
+# load ASDF, either from home dir or brew install
+if [ -f "$HOME/.asdf/asdf.sh" ]; then
   . $HOME/.asdf/asdf.sh
+elif ASDF_PREFIX=$(brew --prefix asdf); then
+  . $ASDF_PREFIX/asdf.sh
 fi
 
 # mkdir .git/safe in the root of repositories you trust

--- a/zsh/configs/post/path.zsh
+++ b/zsh/configs/post/path.zsh
@@ -3,9 +3,11 @@ PATH="$HOME/.bin:/usr/local/sbin:$PATH"
 
 # load ASDF, either from home dir or brew install
 if [ -f "$HOME/.asdf/asdf.sh" ]; then
-  . $HOME/.asdf/asdf.sh
-elif ASDF_PREFIX=$(brew --prefix asdf); then
-  . $ASDF_PREFIX/asdf.sh
+  . "$HOME/.asdf/asdf.sh"
+elif [ -f "/usr/local/opt/asdf/asdf.sh" ]; then
+  . "/usr/local/opt/asdf/asdf.sh"
+elif which brew >/dev/null && ASDF_PREFIX=$(brew --prefix asdf); then
+  . "$ASDF_PREFIX/asdf.sh"
 fi
 
 # mkdir .git/safe in the root of repositories you trust

--- a/zsh/configs/post/path.zsh
+++ b/zsh/configs/post/path.zsh
@@ -4,14 +4,10 @@ PATH="$HOME/.bin:/usr/local/sbin:$PATH"
 # Try loading ASDF from the regular home dir location
 if [ -f "$HOME/.asdf/asdf.sh" ]; then
   . "$HOME/.asdf/asdf.sh"
-# It's not in the home dir, let's try the default Homebrew location
-elif [ -f "/usr/local/opt/asdf/asdf.sh" ]; then
-  . "/usr/local/opt/asdf/asdf.sh"
-# Not there either! Last try, let's see if Homebrew can tell us where it is
 elif which brew >/dev/null &&
-  ASDF_PREFIX=$(brew --prefix asdf) &&
-  [ -f "$ASDF_PREFIX/asdf.sh" ]; then
-  . "$ASDF_PREFIX/asdf.sh"
+  BREW_DIR=$(which brew | sed 's/\/bin\/brew//') &&
+  [ -f "$BREW_DIR/opt/asdf/asdf.sh" ]; then
+  . "$BREW_DIR/opt/asdf/asdf.sh"
 fi
 
 # mkdir .git/safe in the root of repositories you trust


### PR DESCRIPTION
If `asdf` has been installed via Homebrew the completions file is in a
different place. This PR takes that possibility into account.