### PR TITLE
Make Homebrew analytics opt-in

### DIFF
--- a/zsh/configs/homebrew.zsh
+++ b/zsh/configs/homebrew.zsh
@@ -1,0 +1,4 @@
+# To opt in to Homebrew analytics, `unset` this in ~/.zshrc.local .
+# Learn more about what you are opting in to at
+# https://docs.brew.sh/Analytics
+export HOMEBREW_NO_ANALYTICS=1


### PR DESCRIPTION
Currently [Homebrew implements analytics] as opt-out, forcing it on its
users without their enthusiastic consent or a full understanding of the
implications.

This changes it to opt-in: we opt-out by default, and to opt in to
Homebrew analytics we can override it in `~/.zshrc.local`:

```sh
unset HOMEBREW_NO_ANALYTICS
```

[Homebrew implements analytics]: https://docs.brew.sh/Analytics