### PR TITLE
Add easier tmux binding keys - to split window horizontally and vertically

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -30,6 +30,9 @@ set -g status-right ''
 # allow ctrl + b + - to split window horizontally
 bind - split-window -v 
 
+# allow ctrl + b + | to split window vertically
+bind split-window -h
+
 # increase scrollback lines
 set -g history-limit 10000
 

--- a/tmux.conf
+++ b/tmux.conf
@@ -30,7 +30,8 @@ set -g status-right ''
 # prefix + - split window horizontally
 bind-key - split-window -v  -c '#{pane_current_path}'
 
-# prefix + \\ split window vertically
+# prefix + \ split window vertically
+# Note: As of tmux 3.0, we need to escape backslashes
 bind-key \\ split-window -h  -c '#{pane_current_path}'
 
 # increase scrollback lines

--- a/tmux.conf
+++ b/tmux.conf
@@ -31,7 +31,7 @@ set -g status-right ''
 bind - split-window -v 
 
 # allow ctrl + b + | to split window vertically
-bind split-window -h
+bind | split-window -h
 
 # increase scrollback lines
 set -g history-limit 10000

--- a/tmux.conf
+++ b/tmux.conf
@@ -27,6 +27,9 @@ set -g status-fg '#aaaaaa'
 set -g status-left ''
 set -g status-right ''
 
+# allow ctrl + b + - to split window horizontally
+bind - split-window -v 
+
 # increase scrollback lines
 set -g history-limit 10000
 

--- a/tmux.conf
+++ b/tmux.conf
@@ -27,11 +27,11 @@ set -g status-fg '#aaaaaa'
 set -g status-left ''
 set -g status-right ''
 
-# allow ctrl + b + - to split window horizontally
-bind - split-window -v 
+# prefix + - split window horizontally
+bind-key - split-window -v  -c '#{pane_current_path}'
 
-# allow ctrl + b + | to split window vertically
-bind | split-window -h
+# prefix + \\ split window vertically
+bind-key \\ split-window -h  -c '#{pane_current_path}'
 
 # increase scrollback lines
 set -g history-limit 10000


### PR DESCRIPTION
PR adds adds custom tmux binding keys to split window horizontally and vertically. 

Tmux Invocation for horizontal split: 
```
Ctrl + b + - 
```

Tmux Invocation for vertical split: 
```
Ctrl + b + /
```