### PR TITLE
Remove meta files deletion instructions from README

### DIFF
--- a/README-ES.md
+++ b/README-ES.md
@@ -38,8 +38,6 @@ directorio principal.
 Establecer la variable de entorno le dice a `rcup` que use las opciones de
 configuración preestablecidas:
 
-* Excluye los archivos `README.md`, `README-ES.md` y `LICENSE`, que son parte
-  del repositorio `dotfiles`, pero no necesitan enlazarse simbólicamente.
 * Le da precedencia a las modificaciones personales que por defecto están en
   `~/dotfiles-local`
 * Por favor configura el archivo `rcrc` en caso de que quieras hacer

--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ This command will create symlinks for config files in your home directory.
 Setting the `RCRC` environment variable tells `rcup` to use standard
 configuration options:
 
-* Exclude the `README.md`, `README-ES.md` and `LICENSE` files, which are part of
-  the `dotfiles` repository but do not need to be symlinked in.
 * Give precedence to personal overrides which by default are placed in
   `~/dotfiles-local`
 * Please configure the `rcrc` file if you'd like to make personal


### PR DESCRIPTION
These files are not copied by rcm anymore as they are ignored by the [`rcrc`](https://github.com/thoughtbot/dotfiles/blob/master/rcrc) file.