### PR TITLE
Use tmux 1.9+ syntax for status styling

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -20,8 +20,7 @@ set-window-option -g pane-base-index 1
 set -g renumber-windows on
 
 # soften status bar color from harsh green to light gray
-set -g status-bg '#666666'
-set -g status-fg '#aaaaaa'
+set -g status-style bg='#666666',fg='#aaaaaa'
 
 # remove administrative debris (session name, hostname, time) in status bar
 set -g status-left ''


### PR DESCRIPTION
As of tmux 1.9, the `-bg`, `-fg`, and `-attr` options were condensed
into a single `-style` option, which takes a comma-separated list of
options.

In tmux 2.9, the old options were fully removed.

See https://git.io/fjR7c for more information.