### PR TITLE
Replace CtrlP with FZF

### DIFF
--- a/README-ES.md
+++ b/README-ES.md
@@ -182,7 +182,7 @@ sin importar de nombre del archivo:
 
 Configuración [vim](http://www.vim.org/):
 
-* [Ctrl-P](https://github.com/ctrlpvim/ctrlp.vim) para hallazgo difuso de archivos/buffer/tags.
+* [fzf](https://github.com/junegunn/fzf.vim) para hallazgo difuso de archivos/buffer/tags.
 * [Rails.vim](https://github.com/tpope/vim-rails) para una mejor navegación de la estructura
 de archivos de Rails via `gf` y `:A` (alterno), `:Rextract` parciales,`:Rinvert` migraciones, etc.
 * Ejecuta muchos tipos de pruebas [desde vim]([https://github.com/janko-m/vim-test)

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ What's in it?
 
 [vim](http://www.vim.org/) configuration:
 
-* [Ctrl-P](https://github.com/ctrlpvim/ctrlp.vim) for fuzzy file/buffer/tag finding.
+* [fzf](https://github.com/junegunn/fzf.vim) for fuzzy file/buffer/tag finding.
 * [Rails.vim](https://github.com/tpope/vim-rails) for enhanced navigation of
   Rails file structure via `gf` and `:A` (alternate), `:Rextract` partials,
   `:Rinvert` migrations, etc.

--- a/vimrc
+++ b/vimrc
@@ -91,11 +91,8 @@ if executable('ag')
   " Use Ag over Grep
   set grepprg=ag\ --nogroup\ --nocolor
 
-  " Use ag in CtrlP for listing files. Lightning fast and respects .gitignore
-  let g:ctrlp_user_command = 'ag --literal --files-with-matches --nocolor --hidden -g "" %s'
-
-  " ag is fast enough that CtrlP doesn't need to cache
-  let g:ctrlp_use_caching = 0
+  " Use ag in fzf for listing files. Lightning fast and respects .gitignore
+  let $FZF_DEFAULT_COMMAND = 'ag --literal --files-with-matches --nocolor --hidden -g ""'
 
   if !exists(":Ag")
     command -nargs=+ -complete=file -bar Ag silent! grep! <args>|cwindow|redraw!
@@ -161,6 +158,9 @@ nnoremap <C-l> <C-w>l
 " Move between linting errors
 nnoremap ]r :ALENextWrap<CR>
 nnoremap [r :ALEPreviousWrap<CR>
+
+" Map Ctrl + p to open fuzzy find (FZF)
+nnoremap <c-p> :Files<cr>
 
 " Set spellfile to location that is guaranteed to exist, can be symlinked to
 " Dropbox or kept in Git and managed outside of thoughtbot/dotfiles using rcm.

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -16,7 +16,12 @@ call plug#begin('~/.vim/bundle')
 
 " Define bundles via Github repos
 Plug 'christoomey/vim-run-interactive'
-Plug 'ctrlpvim/ctrlp.vim'
+if executable('fzf')
+  Plug '/usr/local/opt/fzf'
+else
+  Plug 'junegunn/fzf', { 'dir': '~/.fzf', 'do': './install --all' }
+endif
+Plug 'junegunn/fzf.vim'
 Plug 'elixir-lang/vim-elixir'
 Plug 'fatih/vim-go'
 Plug 'janko-m/vim-test'


### PR DESCRIPTION
We noticed this has been attempted once before but decided it was time to re-open the discussion. The previous discussion can be found here: https://github.com/thoughtbot/dotfiles/pull/559.

Summary:
Using CtrlP has proven to be slower and has fewer features. We've been
switching over to FZF on a frequent enough basis that it feels
appropriate to make FZF the new default for fuzzy searching.

By swapping out Ctrlp in favor of FZF, this should not break anyone's
fuzzy search but it will replace the tool that executes the search.

We believe that the dependency management concern is addressed by
first checking if FZF is available as an executable with the fallback of vim
plug's installation handling the installation of FZF. FZF is also written by
the creator and maintainer of Vim-Plug.

Co-authored-by: Chris Toomey <chris@ctoomey.com>