### PR TITLE
Set tags for Fugitive

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -145,6 +145,9 @@ nnoremap <Leader>r :RunInInteractiveShell<Space>
 " Treat <li> and <p> tags like the block tags they are
 let g:html_indent_tags = 'li\|p'
 
+" Set tags for vim-fugitive
+set tags^=.git/tags
+
 " Open new split panes to right and bottom, which feels more natural
 set splitbelow
 set splitright


### PR DESCRIPTION
A recent change on vim-fugitive has removed 'tags' support and urges to use `:set tags`.

Link: https://github.com/tpope/vim-fugitive/commit/63a05a6935ec4a45551bf141089c13d5671202a1
