### PR TITLE
Aligning source loading with documentation

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -24,6 +24,6 @@
 [rebase]
   autosquash = true
 [include]
-  path = ~/.gitconfig.local
+  path = ~/dotfiles-local/gitconfig.local
 [diff]
   colorMoved = zebra

--- a/zshrc
+++ b/zshrc
@@ -35,7 +35,9 @@ _load_settings() {
 _load_settings "$HOME/.zsh/configs"
 
 # Local config
-[[ -f ~/.zshrc.local ]] && source ~/.zshrc.local
+[[ -f ~/dotfiles-local/zshrc.local ]] && source ~/dotfiles-local/zshrc.local
 
 # aliases
 [[ -f ~/.aliases ]] && source ~/.aliases
+
+[ -f ~/.fzf.zsh ] && source ~/.fzf.zsh


### PR DESCRIPTION
Noticed that gitconfig and zshrc were loading from the wrong spots if
one was following the documentation to set up their dotfiles. There might be more like this that I am happy to also fix, but these were the immediate ones that I noticed.