### PR TITLE
Clean up adjacent aliases with backslashes

### DIFF
--- a/aliases
+++ b/aliases
@@ -1,16 +1,16 @@
 # Unix
-alias ll="ls -al"
-alias ln="ln -v"
-alias mkdir="mkdir -p"
-alias e="$EDITOR"
-alias v="$VISUAL"
+alias ll="ls -al" \
+ln="ln -v" \
+mkdir="mkdir -p" \
+e="$EDITOR" \
+v="$VISUAL"
 
 # Bundler
 alias b="bundle"
 
 # Rails
-alias migrate="rake db:migrate db:rollback && rake db:migrate db:test:prepare"
-alias s="rspec"
+alias migrate="rake db:migrate db:rollback && rake db:migrate db:test:prepare" \
+s="rspec"
 
 # Pretty print the path
 alias path='echo $PATH | tr -s ":" "\n"'


### PR DESCRIPTION
Some Bash built-ins like export, alias can be run once instead of multiple times by using multiple arguments instead of calling it 6 times in a row for 6 alias. I also think the config looks nicer as a result.