### PR TITLE
gemrc: Remove deprecated `update_sources` option

### DIFF
--- a/gemrc
+++ b/gemrc
@@ -1,1 +1,7 @@
-gem: --no-document
+---
+:backtrace: false
+:bulk_threshold: 1000
+:sources:
+- https://rubygems.org/
+:verbose: true
+:concurrent_downloads: 8


### PR DESCRIPTION
This option has been deprecated and ignored for a long time.

https://github.com/rubygems/rubygems/commit/6f5bf65969e669323af44438382f6851057195c1

https://guides.rubygems.org/command-reference/