### PR TITLE
Update description of `migrate` alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Shell aliases and scripts:
 
 * `b` for `bundle`.
 * `g` with no arguments is `git status` and with arguments acts like `git`.
-* `migrate` for `rake db:migrate && rake db:rollback && rake db:migrate`.
+* `migrate` for `rake db:migrate db:rollback && rake db:migrate db:test:prepare`.
 * `mcd` to make a directory and change into it.
 * `replace foo bar **/*.rb` to find and replace within a given list of files.
 * `tat` to attach to tmux session named the same as the current directory.


### PR DESCRIPTION
Update the README description of the `migrate` alias to match the actual alias