### PR TITLE
Revise how we check for existing FZF executable

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -16,11 +16,15 @@ call plug#begin('~/.vim/bundle')
 
 " Define bundles via Github repos
 Plug 'christoomey/vim-run-interactive'
-if executable('fzf')
+
+" If fzf has already been installed via Homebrew, use the existing fzf
+" Otherwise, install fzf. The `--all` flag makes fzf accessible outside of vim
+if isdirectory("/usr/local/opt/fzf")
   Plug '/usr/local/opt/fzf'
 else
   Plug 'junegunn/fzf', { 'dir': '~/.fzf', 'do': './install --all' }
 endif
+
 Plug 'junegunn/fzf.vim'
 Plug 'elixir-lang/vim-elixir'
 Plug 'fatih/vim-go'


### PR DESCRIPTION
Summary:
This change addresses an error that occurs when we've instructed vim to
reference the wrong path for an existing FZF executable.

Additional Details:
In the previous approach, when checking if FZF has already been
installed, we make the assumption that if FZF is `executable` it was
installed via Homebrew. Then, based on that assumption, we set vim's
`runtimepath` to reference the directory where Homebrew creates symlinks
for installed packages (`/user/local/opt`).

Because of this assumption, anyone that has FZF installed in a different
directory, and available as an executable in their $PATH, attempting to
use FZF within vim will result in an error. The reason vim errors is
because `Plug` has instructed vim's `runtimepath` to look in the wrong
location for FZF (in this case, we told vim to look for FZF within
`/user/local/opt` when the FZF executable lives somewhere else).

The revised approach still attempts to find an existing FZF package
before proceeding with installing FZF.