### PR TITLE
Move extendedglob from Options.zsh to zshrc

### DIFF
--- a/zsh/configs/options.zsh
+++ b/zsh/configs/options.zsh
@@ -2,8 +2,5 @@
 setopt autocd autopushd pushdminus pushdsilent pushdtohome cdablevars
 DIRSTACKSIZE=5
 
-# Enable extended globbing
-setopt extendedglob
-
 # Allow [ or ] whereever you want
 unsetopt nomatch

--- a/zshrc
+++ b/zshrc
@@ -3,6 +3,9 @@ for function in ~/.zsh/functions/*; do
   source $function
 done
 
+# Enable extended globbing for use in _load_settings()
+setopt extendedglob
+
 # extra files in ~/.zsh/configs/pre , ~/.zsh/configs , and ~/.zsh/configs/post
 # these are loaded first, second, and third, respectively.
 _load_settings() {


### PR DESCRIPTION
### Issue
This addresses the issue pointed out in https://github.com/thoughtbot/dotfiles/issues/634

### Description
Introduced in https://github.com/thoughtbot/dotfiles/commit/46af61168b07f3d738d461eb638eb5824bbeb813, the `_loadSettings()` func requires `extendedglob`. 

As such, its been moved from `options.zsh` to the `zshrc` file.