### PR TITLE
Adds a commit-msg git hook

### DIFF
--- a/git_template/hooks/commit-msg
+++ b/git_template/hooks/commit-msg
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+local_hook="$HOME"/.git_template.local/hooks/commit-msg
+
+if [ -f "$local_hook" ]; then
+  . "$local_hook"
+fi


### PR DESCRIPTION
People may wish to configure a `commit-msg` hook in their local
dotfiles.

This allows them to do so by adding a [`commit-msg` git hook][1] that
checks for the presence of a local `commit-msg` hook, and runs it if
present. This hook follows the existing pattern we use for other git
hooks.

[1]: https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks