### PR TITLE
ensure good exit status for aliases script

### DIFF
--- a/aliases
+++ b/aliases
@@ -16,4 +16,6 @@ alias s="rspec"
 alias path='echo $PATH | tr -s ":" "\n"'
 
 # Include custom aliases
-[[ -f ~/.aliases.local ]] && source ~/.aliases.local
+if [[ -f ~/.aliases.local ]]; then
+  source ~/.aliases.local
+fi


### PR DESCRIPTION
if the aliases script is the last thing that your dotfiles setup loads, and if you do not have an ~/.aliases.local file, aliases returned a bad exit status. normally you wouldn't notice this, but if you have your prompt set up to show bad exit statuses, like I do, this was annoying, since each new terminal tab yelled at you in red. this change preserves existing functionality and prevents the script from returning a bad exit status. thanks for this awesome dotfiles setup!