### PR TITLE
Remove `co-pr` git alias

### DIFF
--- a/bin/git-co-pr
+++ b/bin/git-co-pr
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-set -e
-
-git fetch origin "pull/$1/head:pr/$1"
-git checkout "pr/$1"


### PR DESCRIPTION
This alias was added in [`49a4597`][49a4597] to make it easy to checkout
GitHub pull requests. The new [GitHub CLI][github-cli] now comes with a
command for doing just that: `gh pr checkout 123`.

[49a4597]: https://github.com/thoughtbot/dotfiles/commit/49a4597dc4ed039f5c5d020e993dfe680636d6b9
[github-cli]: https://cli.github.com/manual/gh_pr_checkout

Note:

- A related PR switches the laptop script from hub to GitHub CLI: https://github.com/thoughtbot/laptop/pull/576
- If we merge this, we’ll want to update our [‘Accepting a GitHub Pull Request’](https://github.com/thoughtbot/guides/blob/master/protocol/open-source/README.md#accepting-a-github-pull-request) protocol