### PR TITLE
Configure asdf's `legacy_version_file` setting

### DIFF
--- a/asdfrc
+++ b/asdfrc
@@ -1,0 +1,1 @@
+legacy_version_file = yes


### PR DESCRIPTION
asdf has a very useful configuration setting called
`legacy_version_file`. When it is set to `yes`, asdf will read the
version files used by other version managers (e.g. `.ruby-version`) in
addition to asdf's own `.tool-versions` file. This makes the migration
to asdf much smoother, as many projects only specify these 'legacy'
dotfiles for versioning.

Documentation: https://asdf-vm.com/#/core-configuration?id=homeasdfrc

Closes https://github.com/thoughtbot/dotfiles/issues/654