### PR TITLE
Enable mouse for tmux?

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -37,5 +37,8 @@ bind-key C-s send-prefix -2
 # don't suspend-client
 unbind-key C-z
 
+# enable mouse/trackpad
+set -g mouse on
+
 # Local config
 if-shell "[ -f ~/.tmux.conf.local ]" 'source ~/.tmux.conf.local'


### PR DESCRIPTION
Mouse/trackpad support used to be problematic in tmux, but seems to be well supported in newer versions with a simple `set -g mouse on`.

(I realise that not needing the mouse is one of tmux's major selling points, but for scrolling back in a terminal I still find it the most effective way).