### PR TITLE
Allow flexible trunk branch name for `git-up`

### DIFF
--- a/bin/git-up
+++ b/bin/git-up
@@ -2,5 +2,12 @@
 
 set -e
 
-git fetch origin
-git rebase origin/master "$@"
+if git symbolic-ref --short refs/remotes/origin/HEAD >/dev/null; then
+  git rebase "$(git symbolic-ref --short refs/remotes/origin/HEAD | sed 's@^origin/@@')" "$@"
+else
+  echo "You don't have a primary branch reference set for your origin remote.
+Use:
+git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/{name_of_your_primary_branch}
+
+to set the reference and then try rebasing again."
+fi


### PR DESCRIPTION
Our team is renaming the base branch of our application from `master` to
`trunk`. I had held off on doing this in the past because `git up -i`
has become such an huge muscle memory thing and I didn't want a script
to only work on some of my frequent repositories.

This [trick from Stack Overflow](https://stackoverflow.com/a/49384283/1190970) shows how to grab the name of the primary branch for a remote branch without an expensive git operation. It'll allow a rebase against the tip of the primary
remote branch regardless of its name.
