### PR TITLE
Accept optional branch name (to facilitate moving to "main")

### DIFF
--- a/bin/git-merge-branch
+++ b/bin/git-merge-branch
@@ -11,7 +11,7 @@ else
 
   to set the reference and then try merging again."
 
-  exit
+  exit 1
 fi
 
 git fetch origin

--- a/bin/git-merge-branch
+++ b/bin/git-merge-branch
@@ -1,14 +1,20 @@
 #!/bin/sh
 
+main_branch="master"
+
+if [ $# -gt 0 ]; then
+  main_branch=$1
+fi
+
 set -e
 
 git fetch origin
-line_count=$(git diff origin/master..master | wc -l)
+line_count=$(git diff origin/$main_branch..$main_branch | wc -l)
 
 if [ $line_count -gt 0 ]; then
-  printf "failed: master is not up to date with origin/master\n"
+  printf "failed: $main_branch is not up to date with origin/$main_branch\n"
   exit 1
 fi
 
-git checkout master
+git checkout $main_branch
 git merge "@{-1}"

--- a/bin/git-merge-branch
+++ b/bin/git-merge-branch
@@ -1,12 +1,18 @@
 #!/bin/sh
 
-main_branch="master"
-
-if [ $# -gt 0 ]; then
-  main_branch=$1
-fi
-
 set -e
+
+if git symbolic-ref --short refs/remotes/origin/HEAD >/dev/null; then
+  main_branch="$(git symbolic-ref --short refs/remotes/origin/HEAD | sed 's@^origin/@@')" "$@"
+else
+  echo "You don't have a primary branch reference set for your origin remote.
+  Use:
+  git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/{name_of_your_primary_branch}
+
+  to set the reference and then try merging again."
+
+  exit
+fi
 
 git fetch origin
 line_count=$(git diff origin/$main_branch..$main_branch | wc -l)


### PR DESCRIPTION
There's been a recent movement to rename the "master" branch in git
repositories to "main" to avoid to potentially problematic word
"master". Our `merge-branch` script was hard coded to "master". This PR
makes it possible to pass in the name of the branch you wish to merge
to. I've defaulted it to "master" for now, but I expect in time this
will change.