### PR TITLE
Add fetch into Git "up" function

### DIFF
--- a/bin/git-up
+++ b/bin/git-up
@@ -2,6 +2,8 @@
 
 set -e
 
+git fetch origin
+
 if git symbolic-ref --short refs/remotes/origin/HEAD >/dev/null; then
   git rebase "$(git symbolic-ref --short refs/remotes/origin/HEAD | sed 's@^origin/@@')" "$@"
 else


### PR DESCRIPTION
In [a previous commit], we removed the fetching of the "origin" remote from the "up" Git function. With this change, developers had to fetch manually before rebasing their branch. We added the fetch back into the "up" Git function.

[a previous commit]: https://github.com/thoughtbot/dotfiles/commit/f252ba46d101c442ba7340b343512f8873acf27c#diff-b973d5fb5d66981ace5c069881095355