### PR TITLE
Fetch origin and rebase against origin with `git-up`

### DIFF
--- a/bin/git-up
+++ b/bin/git-up
@@ -3,7 +3,8 @@
 set -e
 
 if git symbolic-ref --short refs/remotes/origin/HEAD >/dev/null; then
-  git rebase "$(git symbolic-ref --short refs/remotes/origin/HEAD | sed 's@^origin/@@')" "$@"
+  git fetch origin
+  git rebase "$(git symbolic-ref --short refs/remotes/origin/HEAD)" "$@"
 else
   echo "You don't have a primary branch reference set for your origin remote.
 Use:


### PR DESCRIPTION
In f252ba4 we lost some of the functionality of `git-up`. This change
brings back rebasing against the origin's reference and not the local
reference of the main branch. We also explicitly fetch from `origin` now
to be sure we're current before rebasing.

Close #671
