### PR TITLE
Initialize new repositories with a main branch

### DIFF
--- a/git_template/HEAD
+++ b/git_template/HEAD
@@ -1,0 +1,1 @@
+ref: refs/heads/main

--- a/rcrc
+++ b/rcrc
@@ -1,2 +1,3 @@
 EXCLUDES="README*.md LICENSE"
 DOTFILES_DIRS="$HOME/dotfiles-local $HOME/dotfiles"
+COPY_ALWAYS="git_template/HEAD"


### PR DESCRIPTION
New Git repositories start out without any branches, but the HEAD
reference points to "master" by default. This means that the first
commit will create a master branch.

This change adds a HEAD file to the Git template with a different ref.
This means that new repositories will commit to a "main" branch by
default instead.

The HEAD file is added to COPY_ALWAYS, because Git's HEAD must be a
regular file and not a symbolic link.