### PR TITLE
Set filetype for `typescriptreact` to `typescript`

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -50,6 +50,7 @@ augroup vimrcEx
   autocmd BufRead,BufNewFile aliases.local,zshrc.local,*/zsh/configs/* set filetype=sh
   autocmd BufRead,BufNewFile gitconfig.local set filetype=gitconfig
   autocmd BufRead,BufNewFile tmux.conf.local set filetype=tmux
+  autocmd BufRead,BufNewFile *.tsx set filetype=typescript
   autocmd BufRead,BufNewFile vimrc.local set filetype=vim
 augroup END
 


### PR DESCRIPTION
As of vim v8.1.1930 (and nvim v0.4.0), *.tsx files get a default filetype of typescriptreact. Many plugins do not recognize `typescriptreact`.

This changes the filetype back to `typescript` from `typescriptreact`. 

I am making this PR to discuss, not necessarily to merge. I do not know the full repercussions of this change, or if there is more elegant way to handle this.