### PR TITLE
Use defaultBranch instead of git_template

### DIFF
--- a/git_template/HEAD
+++ b/git_template/HEAD
@@ -1,1 +1,0 @@
-ref: refs/heads/main

--- a/gitconfig
+++ b/gitconfig
@@ -1,4 +1,5 @@
 [init]
+  defaultBranch = main
   templatedir = ~/.git_template
 [push]
   default = current

--- a/hooks/post-up
+++ b/hooks/post-up
@@ -8,9 +8,16 @@ else
   curl -fLo "$HOME"/.vim/autoload/plug.vim --create-dirs \
       https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 fi
+
 vim -u "$HOME"/.vimrc.bundles +PlugUpdate +PlugClean! +qa
 
 reset -Q
+
+if [ -f "$HOME/.git_template/HEAD" ] && \
+  [ "$(cat "$HOME/.git_template/HEAD")" = "ref: refs/heads/main" ]; then
+  echo "Removing ~/.git_template/HEAD in favor of defaultBranch" >&2
+  rm -f ~/.git_template/HEAD
+fi
 
 # detect old OS X broken /etc/zshenv and suggest rename
 if grep -qw path_helper /etc/zshenv 2>/dev/null; then


### PR DESCRIPTION
Git 2.28 now has a setting to change the default branch for new
repositories. This sets init.defaultBranch to main and removes the HEAD
file from the git template.

The HEAD file will need to be removed from ~/.git_template manually, as
rcup does not remove deleted files.

https://github.blog/2020-07-27-highlights-from-git-2-28/#introducing-init-defaultbranch