### PR TITLE
Don't gitignore tags/ directories

### DIFF
--- a/gitignore
+++ b/gitignore
@@ -14,3 +14,4 @@ db/*.sqlite3
 log/*.log
 rerun.txt
 tmp/**/*
+/tags

--- a/gitignore
+++ b/gitignore
@@ -1,4 +1,3 @@
-!tags/
 *.pyc
 *.sw[nop]
 .DS_Store
@@ -14,5 +13,4 @@
 db/*.sqlite3
 log/*.log
 rerun.txt
-tags
 tmp/**/*


### PR DESCRIPTION
For example, the [rails/rails][] project has an entire directory of
classes with `tags` in the name, which hides it from search tools (like
[`ag` The Silver Searcher][ag]) and prevents committing changes or
introducing new files.

Support for ignoring [files named `tags`][git_template/hooks], but
including _directories_ named `tags/` was originally introduced in
[a99fbb0][], but was subsequently broken when the [negative `!tags/`
pattern declaration][] was moved _above_ the `tags` line that it
negated.

Instead of fighting the ignore patterns, this commit removes both lines.
We currently ignore the contents of the [`.git/` directory][.git/],
which is where [we store the `tags` file generated in our
`git_template/hooks/ctags` command][git_template/hooks], so we should be
covered without explicit declarations.

[rails/rails]: https://github.com/rails/rails/tree/master/actionview/lib/action_view/helpers/tags
[ag]: https://github.com/ggreer/the_silver_searcher/tree/2.2.0#whats-so-great-about-ag
[a99fbb0]: https://github.com/thoughtbot/dotfiles/commit/a99fbb0f575c671fb7f481961de05e604c0b1fde
[gitignore-pattern]: https://git-scm.com/docs/gitignore#_pattern_format
[git_template/hooks]: https://github.com/thoughtbot/dotfiles/blob/56d614f8067c275f4d7b53f3f3a30a5effbeded9/git_template/hooks/ctags#L10
[.git/]: https://github.com/thoughtbot/dotfiles/blob/56d614f8067c275f4d7b53f3f3a30a5effbeded9/gitignore#L8