### PR TITLE
fix: set g:ale_lint_on_text_changed before ale is loaded

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -59,8 +59,7 @@ augroup ale
 
   if g:has_async
     autocmd VimEnter *
-      \ set updatetime=1000 |
-      \ let g:ale_lint_on_text_changed = 0
+      \ set updatetime=1000
     autocmd CursorHold * call ale#Queue(0)
     autocmd CursorHoldI * call ale#Queue(0)
     autocmd InsertEnter * call ale#Queue(0)

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -46,6 +46,7 @@ Plug 'vim-ruby/vim-ruby'
 Plug 'vim-scripts/tComment'
 
 if g:has_async
+  let g:ale_lint_on_text_changed = 0
   Plug 'dense-analysis/ale'
 endif
 


### PR DESCRIPTION
ALE's `ale_lint_on_text_changed` option must be set before ALE is loaded, otherwise it's not working. That option is only used when ALE is initialized. Ref https://github.com/dense-analysis/ale/blob/b91c6c2edd20794ad5637b561ed4c678647a76e5/autoload/ale/events.vim#L97