### PR TITLE
Replace rake commands with bin/rails in aliases

### DIFF
--- a/README-ES.md
+++ b/README-ES.md
@@ -223,7 +223,7 @@ Alias de Shell y scripts:
 
 * `b` para `bundle`.
 * `g` sin argumentos es `git status` y con argumentos funciona como `git`.
-* `migrate` para `rake db:migrate && rake db:rollback && rake db:migrate`.
+* `migrate` para `bin/rails db:migrate db:rollback && bin/rails db:migrate db:test:prepare`.
 * `mcd` para crear un directorio e ir a él.
 * `replace foo bar **/*.rb` para buscar y reemplazar en una lista dada de archivos.
 * `tat` para adjuntar a una sesión de tmux llamada igual que el directorio actual.

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Shell aliases and scripts:
 
 * `b` for `bundle`.
 * `g` with no arguments is `git status` and with arguments acts like `git`.
-* `migrate` for `rake db:migrate db:rollback && rake db:migrate db:test:prepare`.
+* `migrate` for `bin/rails db:migrate db:rollback && bin/rails db:migrate db:test:prepare`.
 * `mcd` to make a directory and change into it.
 * `replace foo bar **/*.rb` to find and replace within a given list of files.
 * `tat` to attach to tmux session named the same as the current directory.

--- a/aliases
+++ b/aliases
@@ -9,7 +9,7 @@ alias v="$VISUAL"
 alias b="bundle"
 
 # Rails
-alias migrate="rake db:migrate db:rollback && rake db:migrate db:test:prepare"
+alias migrate="bin/rails db:migrate db:rollback && bin/rails db:migrate db:test:prepare"
 alias s="rspec"
 
 # Pretty print the path


### PR DESCRIPTION
Updating aliases commands from `rake` to `bin/rails` and READMEs