### PR TITLE
markdown files probably never need to be symlinked

### DIFF
--- a/rcrc
+++ b/rcrc
@@ -1,3 +1,3 @@
-EXCLUDES="README*.md LICENSE"
+EXCLUDES="*.md LICENSE"
 DOTFILES_DIRS="$HOME/dotfiles-local $HOME/dotfiles"
 COPY_ALWAYS="git_template/HEAD"


### PR DESCRIPTION
concretely, this adds CODE_OF_CONDUCT.md to the exclude list.