### PR TITLE
Add helper to list process running in a given port

### DIFF
--- a/bin/clear-port
+++ b/bin/clear-port
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Kills the process running on the provided port
+#
+# clear-port 3000
+
+if [ -n "$1" ]; then
+  port_num="$(lsof -ti4TCP:"$1")"
+  if [ $? -eq 0 ]; then
+    kill "$port_num"
+  fi
+else
+  echo >&2 Usage: clear_port port-number
+  exit 1
+fi

--- a/bin/whats-in-port
+++ b/bin/whats-in-port
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# List process running on provided port
+#
+# whats-in-port 3000
+#
+# output:
+# COMMAND   PID   USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
+# ruby    25583   root   11u  IPv4 0xee20607697a79bf7      0t0  TCP *:irdmi (LISTEN)
+
+if [ -n "$1" ]; then
+  lsof -ni4TCP:"$1"
+else
+  echo >&2 Usage: whats_in_port port-number
+  exit 1
+fi


### PR DESCRIPTION
Why:
----

Whenever we run a command to use a certain port and we get an error that the port is in use, we have can either:

1. Clear the port so our new process can use it
2. Try and use a new port for the command we just typed

In order to make a decision about it, we need information on what is running on that port, so we can determine if we want to stop that process or if it's important enough to keep.

What:
----

Two new functions are added for our `zsh` customizations. One to output information about the process using a provided port:

``` bash
whats_in_port 3000
COMMAND   PID   USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
ruby    25583   root   11u  IPv4 0xee20607697a79bf7      0t0  TCP *:irdmi (LISTEN)
```

This command uses the [lsof] program to get information of the process utilising that port.

And another one making use of the previous command to kill the process running in that port:

``` bash
clear_port 3000
```

[lsof]: https://linux.die.net/man/8/lsof
