### PR TITLE
Updated README to use encrypted git connection

### DIFF
--- a/README-ES.md
+++ b/README-ES.md
@@ -15,7 +15,7 @@ Instalar
 
 Clona en tu laptop:
 
-    git clone git://github.com/thoughtbot/dotfiles.git ~/dotfiles
+    git clone git@github.com:thoughtbot/dotfiles.git ~/dotfiles
 
 (o [haz un fork y mantenlo actualizado](http://robots.thoughtbot.com/keeping-a-github-fork-updated)).
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Install
 
 Clone onto your laptop:
 
-    git clone git://github.com/thoughtbot/dotfiles.git ~/dotfiles
+    git clone git@github.com:thoughtbot/dotfiles.git ~/dotfiles
 
 (Or, [fork and keep your fork
 updated](http://robots.thoughtbot.com/keeping-a-github-fork-updated)).


### PR DESCRIPTION
Due to current changes on GitHub, users are forced to use encrypted
connections only, see:
https://github.blog/2021-09-01-improving-git-protocol-security-github/

This is the corresponding change in READMEs.