### PR TITLE
Uses #!/bin/bash instead of #!/bin/sh for bin/ scripts

### DIFF
--- a/bin/bundler-search
+++ b/bin/bundler-search
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Search your bundle for the provided pattern
 #   Requires bundler 1.8+ for execution as a bundler subcommand.

--- a/bin/clear-port
+++ b/bin/clear-port
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Kills the process running on the provided port
 #

--- a/bin/git-ca
+++ b/bin/git-ca
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 
 git commit --amend -v --date="$(date +%Y-%m-%dT%H:%M:%S)"

--- a/bin/git-co-pr
+++ b/bin/git-co-pr
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/bin/git-create-branch
+++ b/bin/git-create-branch
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/bin/git-ctags
+++ b/bin/git-ctags
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/bin/git-current-branch
+++ b/bin/git-current-branch
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/bin/git-delete-branch
+++ b/bin/git-delete-branch
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/bin/git-merge-branch
+++ b/bin/git-merge-branch
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/bin/git-rename-branch
+++ b/bin/git-rename-branch
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/bin/git-trust-bin
+++ b/bin/git-trust-bin
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 
 mkdir -p .git/safe

--- a/bin/git-up
+++ b/bin/git-up
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/bin/replace
+++ b/bin/replace
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Find and replace by a given list of files.
 #

--- a/bin/tat
+++ b/bin/tat
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Attach or create tmux session named the same as current directory.
 

--- a/bin/whats-in-port
+++ b/bin/whats-in-port
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # List process running on provided port
 #


### PR DESCRIPTION
I notice vim's syntax highlighting was wrong for
some bin/ scripts

It was because #!/bin/sh doesn't necessarily support
the $() syntax

As recommended in the thoughtbot's guides:

> Don't use a /bin/sh shebang unless you plan to test
> and run your script on at least: Actual Sh, Dash in
> POSIX-compatible mode (as it will be run on Debian),
> and Bash in POSIX-compatible mode
> (as it will be run on macOS).

https://github.com/thoughtbot/guides/tree/main/shell