### PR TITLE
Do not override :Ag command in vim

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -97,11 +97,6 @@ if executable('ag')
 
   " Use ag in fzf for listing files. Lightning fast and respects .gitignore
   let $FZF_DEFAULT_COMMAND = 'ag --literal --files-with-matches --nocolor --hidden -g ""'
-
-  if !exists(":Ag")
-    command -nargs=+ -complete=file -bar Ag silent! grep! <args>|cwindow|redraw!
-    nnoremap \ :Ag<SPACE>
-  endif
 endif
 
 " Make it obvious where 80 characters is


### PR DESCRIPTION
* The Ag command from fzf.vim that loads the fzf shell does seem
  more useful than than the command being defined here. The one downside
  I see though is that `:Ag some_search` will open the fzf shell rather than
  populating the vim quickfix window, however you can just select all
  files in the fzf shell with alt-a and click enter to add all the files
  in the fzf shell to a quickfix window.
* Remove custom :Ag command vim in favor of :Ag command defined in
  fzf.vim
* Closes #682
