### PR TITLE
Add zprofile with eval command for homebrew

### DIFF
--- a/zprofile
+++ b/zprofile
@@ -1,0 +1,7 @@
+if [ -d "/opt/homebrew" ]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [ -d "~/.linuxbrew" ]; then
+  eval "$(~/.linuxbrew/bin/brew shellenv)"
+elif [ -d "/home/linuxbrew" ]; then
+  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+fi


### PR DESCRIPTION
* I recently setup my M1 mac and had a similar problem to this issue
  reported here https://github.com/thoughtbot/dotfiles/issues/702
  The fix for me was to do what homebrew says after the install which is
  to add to or create a .zprofile with the following command
  `eval "$(/opt/homebrew/bin/brew shellenv)"`
* Introduce a zprofile with commands to eval homebrew on mac or linux if
  the homebrew directory exists
