### PR TITLE
✨ Add a Silver Searcher shortcut

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -97,6 +97,8 @@ if executable('ag')
 
   " Use ag in fzf for listing files. Lightning fast and respects .gitignore
   let $FZF_DEFAULT_COMMAND = 'ag --literal --files-with-matches --nocolor --hidden -g ""'
+
+  nnoremap \ :Ag<SPACE>
 endif
 
 " Make it obvious where 80 characters is


### PR DESCRIPTION
Before, we dropped our custom "Ag" command in favour of the version with fzf.vim. Unfortunately, this change also removed the handy "\\" shortcut to activate Silver Searcher. We added the shortcut back to the Vim configuration.
