### PR TITLE
Git global config to not ignore case

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -16,6 +16,7 @@
 [core]
   excludesfile = ~/.gitignore
   autocrlf = input
+  ignorecase = false
 [merge]
   ff = only
 [commit]


### PR DESCRIPTION
Originally a suggestion by @ACPK here https://github.com/thoughtbot/laptop/issues/601, after discussing it we thought the dotfiles would be a better place for this change.

This change ensures that capitalization change in filenames are tracked via Git, and original case is preserved.