### PR TITLE
Fix sourcing of asdf.sh

### DIFF
--- a/zsh/configs/post/path.zsh
+++ b/zsh/configs/post/path.zsh
@@ -5,9 +5,7 @@ PATH="$HOME/.bin:/usr/local/sbin:$PATH"
 if [ -f "$HOME/.asdf/asdf.sh" ]; then
   . "$HOME/.asdf/asdf.sh"
 elif which brew >/dev/null &&
-  BREW_DIR="$(dirname `which brew`)/.." &&
-  [ -f "$BREW_DIR/opt/asdf/asdf.sh" ]; then
-  . "$BREW_DIR/opt/asdf/asdf.sh"
+  . "$(brew --prefix asdf)/libexec/asdf.sh"
 fi
 
 # mkdir .git/safe in the root of repositories you trust


### PR DESCRIPTION
Installing asdf via Homebrew now requires sourcing from a different path.

This same issue was recently fixed in thoughtbot/laptop by @cpytel, and so I've copied the changes from this commit: https://github.com/thoughtbot/laptop/commit/aa3a84e15e76af9bf3713c350354bc42e59749bc