### PR TITLE
Fix ZSH syntax error

### DIFF
--- a/zsh/configs/post/path.zsh
+++ b/zsh/configs/post/path.zsh
@@ -4,7 +4,7 @@ PATH="$HOME/.bin:/usr/local/sbin:$PATH"
 # Try loading ASDF from the regular home dir location
 if [ -f "$HOME/.asdf/asdf.sh" ]; then
   . "$HOME/.asdf/asdf.sh"
-elif which brew >/dev/null &&
+elif which brew >/dev/null; then
   . "$(brew --prefix asdf)/libexec/asdf.sh"
 fi
 


### PR DESCRIPTION
Fixes the syntax error introduced in #710. Thanks @jasquat for pointing it out!

(Apologies for the previous PR. This time, I've verified it and it's working on my machine)