### PR TITLE
Update the check for fzf installed via homebrew

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -19,8 +19,11 @@ Plug 'christoomey/vim-run-interactive'
 
 " If fzf has already been installed via Homebrew, use the existing fzf
 " Otherwise, install fzf. The `--all` flag makes fzf accessible outside of vim
-let g:brew_fzf_path = trim(system("brew --prefix fzf"))
-if isdirectory(g:brew_fzf_path)
+if executable("brew")
+  let g:brew_fzf_path = trim(system("brew --prefix fzf"))
+endif
+
+if exists("g:brew_fzf_path") && isdirectory(g:brew_fzf_path)
   Plug g:brew_fzf_path
 else
   Plug 'junegunn/fzf', { 'dir': '~/.fzf', 'do': './install --all' }

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -19,8 +19,9 @@ Plug 'christoomey/vim-run-interactive'
 
 " If fzf has already been installed via Homebrew, use the existing fzf
 " Otherwise, install fzf. The `--all` flag makes fzf accessible outside of vim
-if isdirectory("/usr/local/opt/fzf")
-  Plug '/usr/local/opt/fzf'
+let g:brew_fzf_path = trim(system("brew --prefix fzf"))
+if isdirectory(g:brew_fzf_path)
+  Plug g:brew_fzf_path
 else
   Plug 'junegunn/fzf', { 'dir': '~/.fzf', 'do': './install --all' }
 endif


### PR DESCRIPTION
* The existing check for fzf installed via homebrew doesn't work for
  Apple silicon Macs, nor does it work for those who use homebrew on
  Linux.
* Add brew_fzf_path variable to get the brew prefixed path
* Update the isdirectory conditional to check this variable and use it for
  the Plug function call if it is a directory
* Closes #681
