### PR TITLE
Fix broken thoughtbot logo on README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ redistributed under the terms specified in the [`LICENSE`] file.
 About thoughtbot
 ----------------
 
-![thoughtbot](http://presskit.thoughtbot.com/images/thoughtbot-logo-for-readmes.svg)
+![thoughtbot](https://thoughtbot.com/brand_assets/93:44.svg)
 
 dotfiles is maintained and funded by thoughtbot, inc.
 The names and logos for thoughtbot are trademarks of thoughtbot, inc.


### PR DESCRIPTION
The previous thoughtbot logo link is broken. Replace it with another link used on other thoughtbot repositories.

