### PR TITLE
Let users to use the arrow keys

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -127,12 +127,6 @@ inoremap <S-Tab> <C-n>
 " Switch between the last two files
 nnoremap <Leader><Leader> <C-^>
 
-" Get off my lawn
-nnoremap <Left> :echoe "Use h"<CR>
-nnoremap <Right> :echoe "Use l"<CR>
-nnoremap <Up> :echoe "Use k"<CR>
-nnoremap <Down> :echoe "Use j"<CR>
-
 " vim-test mappings
 nnoremap <silent> <Leader>t :TestFile<CR>
 nnoremap <silent> <Leader>s :TestNearest<CR>


### PR DESCRIPTION
During pairing sessions, we encounter difficulties when collaborating
with non-Vim users due to the dotfiles blocking the use of arrow keys,
as `h`, `j`, `k` and `l` motions are unfamiliar to non-Vim users. While
those motions are undoubtedly more productive than arrow keys, blocking
them makes collaboration worse.

Users who want to force themselves to stop using the arrow keys can
add the key mappings to their own local dotfiles, or use a Vim plugin
that includes similar behavior.