### PR TITLE
Adds scripts to use plugins from oh-my-zsh

### DIFF
--- a/bin/oh-my-delete
+++ b/bin/oh-my-delete
@@ -7,6 +7,11 @@ zshconfig_dir=$HOME/.zsh/configs
 name=$1
 source_file=$ohmyzsh_dir/plugins/$name/$name.plugin.zsh
 
+if [ ! -d "$ohmyzsh_dir" ]; then
+    echo "Oh-my-zsh repository is not downloaded in your $HOME directory. Please download it first."
+    exit 1
+fi
+
 # Check if the plugin name is provided
 if [ -n "$1" ]; then
     # Check if the plugin file exists in the oh-my-zsh plugins directory

--- a/bin/oh-my-delete
+++ b/bin/oh-my-delete
@@ -10,12 +10,12 @@ source_file=$ohmyzsh_dir/plugins/$name/$name.plugin.zsh
 # Check if the plugin name is provided
 if [ -n "$1" ]; then
     # Check if the plugin file exists in the oh-my-zsh plugins directory
-    if [ -e $source_file ]; then
+    if [ -e "$source_file" ]; then
         target_file=~/.zshrc
         # Check if the plugin is installed
         if grep -q "source $source_file" "$target_file"; then
             # Deletes the symlink
-            unlink $zshconfig_dir/$name.plugin.zsh
+            unlink "$zshconfig_dir/$name.plugin.zsh"
             # Creates a temp file excluding the line containing the source command for the plugin
             grep -v "source $source_file" "$target_file" > "$target_file.tmp"
             # Replaces the original file with the temp file

--- a/bin/oh-my-delete
+++ b/bin/oh-my-delete
@@ -8,7 +8,7 @@ name=$1
 source_file=$ohmyzsh_dir/plugins/$name/$name.plugin.zsh
 
 if [ ! -d "$ohmyzsh_dir" ]; then
-    echo "Oh-my-zsh repository is not downloaded in your $HOME directory. Please download it first."
+    echo >&2 "Oh-my-zsh repository is not downloaded in your $HOME directory. Please download it first."
     exit 1
 fi
 
@@ -20,11 +20,11 @@ if [ -n "$1" ]; then
         # Check if the plugin is installed
         if grep -q "source $source_file" "$target_file"; then
             # Deletes the symlink
-            unlink "$zshconfig_dir/$name.plugin.zsh"
+            unlink "$zshconfig_dir/$name.plugin.zsh" &&
             # Creates a temp file excluding the line containing the source command for the plugin
-            grep -v "source $source_file" "$target_file" > "$target_file.tmp"
+            grep -v "source $source_file" "$target_file" > "$target_file.tmp" &&
             # Replaces the original file with the temp file
-            mv "$target_file.tmp" "$target_file"
+            mv "$target_file.tmp" "$target_file" &&
             echo >&2 Plugin deleted successfully.
         else
             echo >&2 Plugin is not installed.

--- a/bin/oh-my-delete
+++ b/bin/oh-my-delete
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# This script is used to allow the user to delete plugins or themes from oh-my-zsh
+
+ohmyzsh_dir=$HOME/ohmyzsh
+zshconfig_dir=$HOME/.zsh/configs
+name=$1
+source_file=$ohmyzsh_dir/plugins/$name/$name.plugin.zsh
+
+# Check if the plugin name is provided
+if [ -n "$1" ]; then
+    # Check if the plugin file exists in the oh-my-zsh plugins directory
+    if [ -e $source_file ]; then
+        target_file=~/.zshrc
+        # Check if the plugin is installed
+        if grep -q "source $source_file" "$target_file"; then
+            # Deletes the symlink
+            unlink $zshconfig_dir/$name.plugin.zsh
+            # Creates a temp file excluding the line containing the source command for the plugin
+            grep -v "source $source_file" "$target_file" > "$target_file.tmp"
+            # Replaces the original file with the temp file
+            mv "$target_file.tmp" "$target_file"
+            echo >&2 Plugin deleted successfully.
+        else
+            echo >&2 Plugin is not installed.
+        fi
+    fi
+else
+    echo >&2 Usage: oh-my-delete plugin-name
+    exit 1
+fi

--- a/bin/oh-my-delete
+++ b/bin/oh-my-delete
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# This script is used to allow the user to delete plugins or themes from oh-my-zsh
+# This script is used to allow the user to delete plugins
 
 ohmyzsh_dir=$HOME/ohmyzsh
 zshconfig_dir=$HOME/.zsh/configs

--- a/bin/oh-my-install
+++ b/bin/oh-my-install
@@ -2,7 +2,7 @@
 
 # This script is used to allow the user to install plugins or themes from oh-my-zsh
 
-ohmyzsh_dir=$HOME/desktop/ohmyzsh
+ohmyzsh_dir=$HOME/ohmyzsh
 zshconfig_dir=$HOME/.zsh/configs
 name=$1
 source_file=$ohmyzsh_dir/plugins/$name/$name.plugin.zsh

--- a/bin/oh-my-install
+++ b/bin/oh-my-install
@@ -16,11 +16,11 @@ fi
 # Check if the plugin name is provided
 if [ -n "$1" ]; then
 # Check if the plugin file name exists in the oh-my-zsh plugins directory -> plugins/git/git.plugin.zsh
-  if [ -e $source_file ]; then
+  if [ -e "$source_file" ]; then
       target_file=~/.zshrc
       # check if the plugin is already installed
       if ! grep -q "source $source_file" "$target_file"; then
-          ln -s $source_file $zshconfig_dir
+          ln -s "$source_file" "$zshconfig_dir"
           echo >&2 Symlink created successfully.
           echo "source $source_file" >> "$target_file"
           echo >&2 Added source command to .zshrc

--- a/bin/oh-my-install
+++ b/bin/oh-my-install
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# This script is used to allow the user to install plugins or themes from oh-my-zsh
+# This script is used to allow the user to install plugins
 
 ohmyzsh_dir=$HOME/ohmyzsh
 zshconfig_dir=$HOME/.zsh/configs

--- a/bin/oh-my-install
+++ b/bin/oh-my-install
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# This script is used to allow the user to install plugins or themes from oh-my-zsh
+
+ohmyzsh_dir=$HOME/desktop/ohmyzsh
+zshconfig_dir=$HOME/.zsh/configs
+name=$1
+source_file=$ohmyzsh_dir/plugins/$name/$name.plugin.zsh
+
+# Check if oh-my-zsh repository is downloaded in the home directory
+if [ ! -d "$ohmyzsh_dir" ]; then
+    echo "Oh-my-zsh repository is not downloaded in your $HOME directory. Please download it first."
+    exit 1
+fi
+
+# Check if the plugin name is provided
+if [ -n "$1" ]; then
+# Check if the plugin file name exists in the oh-my-zsh plugins directory -> plugins/git/git.plugin.zsh
+  if [ -e $source_file ]; then
+      target_file=~/.zshrc
+      # check if the plugin is already installed
+      if ! grep -q "source $source_file" "$target_file"; then
+          ln -s $source_file $zshconfig_dir
+          echo >&2 Symlink created successfully.
+          echo "source $source_file" >> "$target_file"
+          echo >&2 Added source command to .zshrc
+      else
+          echo >&2 Plugin already installed
+      fi
+  else
+      echo >&2 Package "$name" does not exist in the oh-my-zsh plugins directory
+      exit 1
+  fi
+else
+  echo >&2 Usage: oh-my-install plugin-name
+  exit 1
+fi

--- a/bin/oh-my-update
+++ b/bin/oh-my-update
@@ -3,7 +3,7 @@
 # This script is used to allow the user to install plugins or themes from ohmyzsh
 
 # Variables
-ohmyzsh_dir=$HOME/desktop/ohmyzsh
+ohmyzsh_dir=$HOME/ohmyzsh
 
 if [ ! -d $ohmyzsh_dir ]; then
     echo "Oh-my-zsh repository is not downloaded in your $HOME directory. Please download it first."

--- a/bin/oh-my-update
+++ b/bin/oh-my-update
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# This script is used to allow the user to install plugins or themes from ohmyzsh
+# This script is used to update the oh-my-zsh repository
 
 # Variables
 ohmyzsh_dir=$HOME/ohmyzsh

--- a/bin/oh-my-update
+++ b/bin/oh-my-update
@@ -13,5 +13,5 @@ fi
 # Move into the folder
 cd "$ohmyzsh_dir" || exit
 echo "Updating latest changes from oh-my-zsh"
-git pull origin master
+git pull origin master &&
 echo "Updated successfully"

--- a/bin/oh-my-update
+++ b/bin/oh-my-update
@@ -5,14 +5,13 @@
 # Variables
 ohmyzsh_dir=$HOME/ohmyzsh
 
-if [ ! -d $ohmyzsh_dir ]; then
+if [ ! -d "$ohmyzsh_dir" ]; then
     echo "Oh-my-zsh repository is not downloaded in your $HOME directory. Please download it first."
     exit 1
 fi
 
 # Move into the folder
-cd $ohmyzsh_dir
+cd "$ohmyzsh_dir" || exit
 echo "Updating latest changes from oh-my-zsh"
 git pull origin master
 echo "Updated successfully"
-

--- a/bin/oh-my-update
+++ b/bin/oh-my-update
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# This script is used to allow the user to install plugins or themes from ohmyzsh
+
+# Variables
+ohmyzsh_dir=$HOME/desktop/ohmyzsh
+
+if [ ! -d $ohmyzsh_dir ]; then
+    echo "Oh-my-zsh repository is not downloaded in your $HOME directory. Please download it first."
+    exit 1
+fi
+
+# Move into the folder
+cd $ohmyzsh_dir
+echo "Updating latest changes from oh-my-zsh"
+git pull origin master
+echo "Updated successfully"
+

--- a/zshrc
+++ b/zshrc
@@ -9,12 +9,12 @@ _load_settings() {
   _dir="$1"
   if [ -d "$_dir" ]; then
     if [ -d "$_dir/pre" ]; then
-      for config in "$_dir"/pre/**/*~*.zwc(N-.); do
+      for config in "$_dir"/pre/**/*~*.zwc(N-.@); do
         . $config
       done
     fi
 
-    for config in "$_dir"/**/*(N-.); do
+    for config in "$_dir"/**/*(N-.@); do
       case "$config" in
         "$_dir"/(pre|post)/*|*.zwc)
           :
@@ -26,7 +26,7 @@ _load_settings() {
     done
 
     if [ -d "$_dir/post" ]; then
-      for config in "$_dir"/post/**/*~*.zwc(N-.); do
+      for config in "$_dir"/post/**/*~*.zwc(N-.@); do
         . $config
       done
     fi


### PR DESCRIPTION
This PR adds functionalities that allow using `oh-my-zsh` plugins with thoughtbot dotfiles.

It adds:

- Script to install `oh-my-zsh` plugins
- Script to update `oh-my-zsh` repository locally
- Script to delete `oh-my-zsh` plugins