### PR TITLE
Add git co-upstream-pr command

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ configuration:
 
 [git](http://git-scm.com/) configuration:
 
+- Adds a `co-upstream-pr $PR_NUMBER $LOCAL_BRANCH_NAME` alias to checkout remote upstream branch into a local branch.
 - Adds a `create-branch` alias to create feature branches.
 - Adds a `delete-branch` alias to delete feature branches.
 - Adds a `merge-branch` alias to merge feature branches into master.

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ configuration:
 
 [git](http://git-scm.com/) configuration:
 
-- Adds a `co-upstream-pr $PR_NUMBER $LOCAL_BRANCH_NAME` alias to checkout remote upstream branch into a local branch.
+- Adds a `co-upstream-pr $PR_NUMBER $LOCAL_BRANCH_NAME` subcommand to checkout remote upstream branch into a local branch.
 - Adds a `create-branch` alias to create feature branches.
 - Adds a `delete-branch` alias to delete feature branches.
 - Adds a `merge-branch` alias to merge feature branches into master.

--- a/bin/git-co-upstream-pr
+++ b/bin/git-co-upstream-pr
@@ -5,13 +5,15 @@ set -e
 pull_request_number=$1
 local_branch_name=$2
 
-if git remote -v | grep upstream; then
+if git remote -v | grep -q upstream; then
   git fetch upstream "pull/$pull_request_number/head:$local_branch_name"
   git checkout "$local_branch_name"
 else
-  echo "You don't have an upstream remote set.
-  Use:
+  cat <<HELP
+You don't have an upstream remote set.
+Use:
   git remote add upstream {upstream_remote_url}
 
-  to set the reference and then try again."
+to set the reference and then try again.
+HELP
 fi

--- a/bin/git-co-upstream-pr
+++ b/bin/git-co-upstream-pr
@@ -5,6 +5,11 @@ set -e
 pull_request_number=$1
 local_branch_name=$2
 
+if [ -z "$pull_request_number" -o -z "$local_branch_name" ]; then
+  echo "usage: git co-upstream-pr <pull_request_number> <local_branch_name>"
+  exit 1
+fi
+
 if git remote -v | grep -q upstream; then
   git fetch upstream "pull/$pull_request_number/head:$local_branch_name"
   git checkout "$local_branch_name"

--- a/bin/git-co-upstream-pr
+++ b/bin/git-co-upstream-pr
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -e
+
+pull_request_number=$1
+local_branch_name=$2
+
+if git remote -v | grep upstream; then
+  git fetch upstream "pull/$pull_request_number/head:$local_branch_name"
+  git checkout "$local_branch_name"
+else
+  echo "You don't have an upstream remote set.
+  Use:
+  git remote add upstream {upstream_remote_url}
+
+  to set the reference and then try again."
+fi


### PR DESCRIPTION
When reviewing Pull Requests from open source projects, it's handy to have a way to just pass the PR number and the local branch name.

With this new command, to fetch a PR from an upstream remote repo, we just need the PR number and the name of the local branch:

$ co-upstream-pr 001 test_generator_pr

git will checkout the upstream PR in the local test_generator_pr branch.

If there is no upstream remote set, we get a nice message guiding users to set it first:

```
You don't have an upstream remote set.
Use:
  git remote add upstream {upstream_remote_url}
  to set the reference and then try again.
```

Co-authored by @minaslater 🎉 