### PR TITLE
Removes obsolete git checkout PR alias

### DIFF
--- a/bin/git-co-pr
+++ b/bin/git-co-pr
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-set -e
-
-git fetch origin "pull/$1/head:pr/$1"
-git checkout "pr/$1"


### PR DESCRIPTION
Opening a new PR since the
[original](https://github.com/thoughtbot/dotfiles/pull/657) can't be reopened anymore.

This alias was added in 49a4597 to make it easy to checkout GitHub pull requests. The new GitHub CLI now comes with a command for doing just that: gh pr checkout 123.

Co-authored-by: Tyson Gach @tysongach