### PR TITLE
Introduce `railsrc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,14 @@ configuration:
 - Add trusted binstubs to the `PATH`.
 - Load the ASDF version manager.
 
+[Rails](https://rubyonrails.org)
+
+- Adds [railsrc][] with `--database=postgresql`. If you need to use another
+  database, you can override this value like so: `rails new my_app --database=mysql` or
+`rails new my_app --no_rc`
+
+[railsrc]: https://github.com/rails/rails/blob/7f7f9df8641e35a076fe26bd097f6a1b22cb4e2d/railties/lib/rails/generators/rails/app/USAGE#L5C1-L7
+
 Shell aliases and scripts:
 
 - `b` for `bundle`.

--- a/railsrc
+++ b/railsrc
@@ -1,0 +1,1 @@
+--database=postgresql


### PR DESCRIPTION
Introduces [railsrc][1] in an effort to prepare for the eventual [removal of the
suspenders executable][2].

With this change, calling `rails new` will automatically set the following
options:

```
--database=postgresql
```

If you need to use another database, you can override this value like so: `rails
new my_app --database=mysql` or `rails new my_app --no_rc` to skip this file all
together

[1]: https://github.com/rails/rails/blob/7f7f9df8641e35a076fe26bd097f6a1b22cb4e2d/railties/lib/rails/generators/rails/app/USAGE#L5C1-L7
[2]: https://github.com/thoughtbot/suspenders/blob/main/GOALS.md#from-here-to-there
