### PR TITLE
✨ Add an `...` alias for quicker navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ configuration:
 
 Shell aliases and scripts:
 
+- `...` for quicker navigation to the parent's parent directory.
 - `b` for `bundle`.
 - `g` with no arguments is `git status` and with arguments acts like `git`.
 - `migrate` for `bin/rails db:migrate db:rollback && bin/rails db:migrate db:test:prepare`.

--- a/aliases
+++ b/aliases
@@ -15,6 +15,9 @@ alias s="rspec"
 # Pretty print the path
 alias path='echo $PATH | tr -s ":" "\n"'
 
+# Easier navigation: ...
+alias ...="cd ../.."
+
 # Include custom aliases
 if [[ -f ~/.aliases.local ]]; then
   source ~/.aliases.local


### PR DESCRIPTION
Before, we would have to use eight keystrokes to move up two directories in the terminal. We wasted so much unnecessary time. We added an `...` alias to reduce the keystrokes and gain productivity.
