### PR TITLE
✨ Add a Downloads alias

### DIFF
--- a/aliases
+++ b/aliases
@@ -20,6 +20,9 @@ alias ...="cd ../.."
 alias ....="cd ../../.."
 alias .....="cd ../../../.."
 
+# Shortcuts
+alias dl="cd ~/Downloads"
+
 # Include custom aliases
 if [[ -f ~/.aliases.local ]]; then
   source ~/.aliases.local


### PR DESCRIPTION
Before, it was a challenge to remember how to navigate to the Downloads directory. We wasted time trying to figure out the correct path. We added a simple `dl` alias to simplify the process.
