### PR TITLE
✨ Add a Desktop alias

### DIFF
--- a/aliases
+++ b/aliases
@@ -20,6 +20,9 @@ alias ...="cd ../.."
 alias ....="cd ../../.."
 alias .....="cd ../../../.."
 
+# Shortcuts
+alias dt="cd ~/Desktop"
+
 # Include custom aliases
 if [[ -f ~/.aliases.local ]]; then
   source ~/.aliases.local


### PR DESCRIPTION
Before, it was a challenge to remember how to navigate to the Desktop directory. We wasted time trying to figure out the correct path. We added a simple `dt` alias to simplify the process.
