### PR TITLE
✨ Add an `-` alias for quicker navigation

### DIFF
--- a/aliases
+++ b/aliases
@@ -15,10 +15,11 @@ alias s="rspec"
 # Pretty print the path
 alias path='echo $PATH | tr -s ":" "\n"'
 
-# Easier navigation: ..., ...., .....
+# Easier navigation: ..., ...., ....., and -
 alias ...="cd ../.."
 alias ....="cd ../../.."
 alias .....="cd ../../../.."
+alias -- -="cd -"
 
 # Include custom aliases
 if [[ -f ~/.aliases.local ]]; then


### PR DESCRIPTION
Before, we would have to use four keystrokes to move to the previous directory in the terminal. We wasted so much unnecessary time. We added an `-` alias to reduce the keystrokes and gain productivity.
