### PR TITLE
Fix sourcing of asdf

### DIFF
--- a/zsh/configs/post/path.zsh
+++ b/zsh/configs/post/path.zsh
@@ -5,9 +5,7 @@ PATH="$HOME/.bin:/usr/local/sbin:$PATH"
 if [ -f "$HOME/.asdf/asdf.sh" ]; then
   . "$HOME/.asdf/asdf.sh"
 # Checking homebrew existance before loading asdf
-elif [ -d "/opt/homebrew" ] || 
-  [ -d "~/.linuxbrew" ] || 
-  [ -d "/home/linuxbrew" ]; then
+elif [[ $(command -v brew) != "" ]]; then
   . "$(brew --prefix asdf)/libexec/asdf.sh"
 fi
 

--- a/zsh/configs/post/path.zsh
+++ b/zsh/configs/post/path.zsh
@@ -4,7 +4,10 @@ PATH="$HOME/.bin:/usr/local/sbin:$PATH"
 # Try loading ASDF from the regular home dir location
 if [ -f "$HOME/.asdf/asdf.sh" ]; then
   . "$HOME/.asdf/asdf.sh"
-elif which brew >/dev/null; then
+# Checking homebrew existance before loading asdf
+elif [ -d "/opt/homebrew" ] || 
+  [ -d "~/.linuxbrew" ] || 
+  [ -d "/home/linuxbrew" ]; then
   . "$(brew --prefix asdf)/libexec/asdf.sh"
 fi
 


### PR DESCRIPTION
From https://github.com/thoughtbot/dotfiles/issues/738

Change the way to check if homebrew is present.
The original code assumed that homebrew was already installed.

This same code was introduced in this commit [#704.](https://github.com/thoughtbot/dotfiles/commit/fc9f7798f85a56297f48785dd07685d5cbf4a1a6) to check if Homebrew is present in the system.