### PR TITLE
Skip zwc zsh function files

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -1,8 +1,3 @@
-# load custom executable functions
-for function in ~/.zsh/functions/*; do
-  source $function
-done
-
 # extra files in ~/.zsh/configs/pre , ~/.zsh/configs , and ~/.zsh/configs/post
 # these are loaded first, second, and third, respectively.
 _load_settings() {
@@ -33,6 +28,11 @@ _load_settings() {
   fi
 }
 _load_settings "$HOME/.zsh/configs"
+
+# load custom executable functions
+for function in ~/.zsh/functions/*~*.zwc; do
+  source $function
+done
 
 # Local config
 [[ -f ~/.zshrc.local ]] && source ~/.zshrc.local


### PR DESCRIPTION
- Uses the `~` glob operator to be consistent with `_load_settings()``
- moved loading after `_load_settings``, because `setopt extendedglob` is needed for the `~` glob operator and is run in `_load_settings()`