### PR TITLE
railsrc: Skip tests when building new application

### DIFF
--- a/railsrc
+++ b/railsrc
@@ -1,1 +1,2 @@
 --database=postgresql
+--skip-test


### PR DESCRIPTION
Follow-up to #728

In an effort to create parity with the [upcoming release of
Suspenders][1], we pass the `--skip-test` argument when running [rails
new][2].

This means if you're using our `railsrc` file, you would just need to
pass the `-m` argument when generating a new Rails application.

[1]: https://github.com/thoughtbot/suspenders/pull/1135
[2]: https://guides.rubyonrails.org/command_line.html#rails-new
