### PR TITLE
Use `default` for asdfrc tool versions setting

### DIFF
--- a/asdfrc
+++ b/asdfrc
@@ -1,1 +1,1 @@
-legacy_version_file = yes
+legacy_version_file = default


### PR DESCRIPTION
https://asdf-vm.com/manage/configuration.html#full-configuration-example
https://asdf-vm.com/manage/configuration.html#legacy-version-file

In #654 we configured asdf to use a "legacy version file" for picking
languages. This enabled us to continue using`.ruby-version` to declare
the Ruby version in a project.

Now that the Gemfile spec supports the use of `.tool-versions`, we can
set this setting to leverage the file and avoid declaring the Ruby (or
Node, etc.) versions of runtimes in multiple places in a project.

This setting is can be overridden on a per-project basis with a local
`.asdfrc` file.
