### PR TITLE
railsrc: Pass `--skip-rubocop`

### DIFF
--- a/railsrc
+++ b/railsrc
@@ -1,3 +1,4 @@
 --database=postgresql
 --skip-test
+--skip-rubocop
 -m=https://raw.githubusercontent.com/thoughtbot/suspenders/main/lib/install/web.rb


### PR DESCRIPTION
This compliments a [change made to Suspenders][1] in which we require
the caller to pass `--skip-rubocop` when invoking `rails new`.

[1]: https://github.com/thoughtbot/suspenders/pull/1223
