### PR TITLE
Exclude CODEOWNERS file from symlinking

### DIFF
--- a/rcrc
+++ b/rcrc
@@ -1,3 +1,3 @@
-EXCLUDES="*.md LICENSE"
+EXCLUDES="*.md LICENSE CODEOWNERS"
 DOTFILES_DIRS="$HOME/dotfiles-local $HOME/dotfiles"
 COPY_ALWAYS="git_template/HEAD"


### PR DESCRIPTION
I think this file wasn't meant to be symlinked (?). Nice that it was easy to figure out how to not link it.

Thanks for this great repo, learnt a ton from it :)