### PR TITLE
✨ Add `ripgrep` support with `ag` fallback

### DIFF
--- a/bin/bundler-search
+++ b/bin/bundler-search
@@ -12,4 +12,8 @@
 #  2. Which gem names to search (defaults to all gems)
 
 pattern="$1"; shift
-ag "$pattern" $(bundle show --paths "$@")
+if command -v rg &>/dev/null; then
+  rg "$pattern" $(bundle show --paths "$@")
+else
+  ag "$pattern" $(bundle show --paths "$@")
+fi

--- a/vimrc
+++ b/vimrc
@@ -91,8 +91,17 @@ set list listchars=tab:»·,trail:·,nbsp:·
 " Use one space, not two, after punctuation.
 set nojoinspaces
 
+" Use ripgrep https://github.com/BurntSushi/ripgrep
+if executable('rg')
+  " Use Rg over Grep
+  set grepprg=rg\ --vimgrep\ --no-heading\ --smart-case
+
+  " Use rg in fzf for listing files. Lightning fast and respects .gitignore
+  let $FZF_DEFAULT_COMMAND = 'rg --files --hidden --follow --glob "!.git/*"'
+
+  nnoremap \ :Rg<SPACE>
 " Use The Silver Searcher https://github.com/ggreer/the_silver_searcher
-if executable('ag')
+elseif executable('ag')
   " Use Ag over Grep
   set grepprg=ag\ --nogroup\ --nocolor
 


### PR DESCRIPTION
Before, we relied on [`ag`][] for searching, but the maintainer last updated it five years ago. We want to ensure that folks maintain our tools, and we use the fastest tools available. We added [`ripgrep`][] as an alternative to `ag` but ensured backwards compatibility.

[`ag`]: https://github.com/ggreer/the_silver_searcher
[`ripgrep`]: https://github.com/BurntSushi/ripgrep
