### PR TITLE
🐛 Fix Control-R

### DIFF
--- a/zsh/configs/fzf.zsh
+++ b/zsh/configs/fzf.zsh
@@ -1,0 +1,3 @@
+#!/usr/bin/env zsh
+
+source <(/opt/homebrew/bin/fzf --zsh)

--- a/zsh/configs/keybindings.zsh
+++ b/zsh/configs/keybindings.zsh
@@ -9,7 +9,6 @@ bindkey "^F" vi-cmd-mode
 bindkey "^A" beginning-of-line
 bindkey "^E" end-of-line
 bindkey "^K" kill-line
-bindkey "^R" history-incremental-search-backward
 bindkey "^P" history-search-backward
 bindkey "^Y" accept-and-hold
 bindkey "^N" insert-last-word

--- a/zshrc
+++ b/zshrc
@@ -34,6 +34,8 @@ _load_settings() {
 }
 _load_settings "$HOME/.zsh/configs"
 
+eval "$(/opt/homebrew/bin/brew shellenv)"
+
 # Local config
 [[ -f ~/.zshrc.local ]] && source ~/.zshrc.local
 


### PR DESCRIPTION
Before, we updated thoughtbot's `laptop` script to install `fzf`. We had installed the binary when we included the `fzf` Vim plugin. By installing the executable as part of `laptop`, we broke Control-R. We fixed Control-R by sourcing the configuration files when we start zsh.

[GitHub](https://github.com/thoughtbot/dotfiles/issues/764)
