### PR TITLE
Improve zsh history configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,22 @@ can add the `virtualenv` file, another `keys`, and a third `chpwd`.
 
 The `~/dotfiles-local/zshrc.local` is loaded after `~/dotfiles-local/zsh/configs`.
 
+## zsh History Configurations
+
+The zsh history is configured with several useful options:
+
+-   `hist_ignore_all_dups`: Removes duplicate commands from history
+
+-   `hist_ignore_space`: Commands starting with a space are not saved to history
+    (useful for sensitive commands)
+
+-   `inc_append_history`: Adds commands to history as they're executed, not just
+    when the shell exits
+
+-   `share_history`: Shares history across multiple zsh sessions in real-time
+
+History size is set to 8,192 entries providing ample command history.
+
 ## vim Configurations
 
 Similarly to the zsh configuration directory as described above, vim

--- a/zsh/configs/history.zsh
+++ b/zsh/configs/history.zsh
@@ -1,6 +1,9 @@
-setopt hist_ignore_all_dups inc_append_history
+#!/usr/bin/env zsh
+
+setopt hist_ignore_all_dups hist_ignore_space inc_append_history share_history
+
 HISTFILE=~/.zhistory
-HISTSIZE=4096
-SAVEHIST=4096
+HISTSIZE=8192
+SAVEHIST=8192
 
 export ERL_AFLAGS="-kernel shell_history enabled"


### PR DESCRIPTION
This PR enhances the `zsh` history experience with a focus on privacy, session sharing, and increased commands in history.

### Changes
- Add `hist_ignore_space` to prevent commands starting with a space from being saved (useful for sensitive commands such as `export secret`)
- Add `share_history` to share command history across multiple zsh sessions in real-time
- Increase history size from 4,096 to 8,192 entries (2x more history)
- Update README with history configuration