### PR TITLE
✨ Add a default Vim `colorscheme`

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -10,6 +10,7 @@ set noswapfile    " http://robots.thoughtbot.com/post/18739402579/global-gitigno
 set history=50
 set ruler         " show the cursor position all the time
 set showcmd       " display incomplete commands
+set termguicolors " make our colors pretty
 set incsearch     " do incremental searching
 set laststatus=2  " Always display the status line
 set autowrite     " Automatically :write before running commands
@@ -169,6 +170,9 @@ set complete+=kspell
 
 " Always use vertical diffs
 set diffopt+=vertical
+
+" Use Catpuccin Latte as our default color scheme
+colorscheme catppuccin_latte
 
 " Local config
 if filereadable($HOME . "/.vimrc.local")

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -29,6 +29,7 @@ else
   Plug 'junegunn/fzf', { 'dir': '~/.fzf', 'do': './install --all' }
 endif
 
+Plug 'catppuccin/vim', { 'as': 'catppuccin' }
 Plug 'junegunn/fzf.vim'
 Plug 'elixir-lang/vim-elixir'
 Plug 'fatih/vim-go'


### PR DESCRIPTION
Before, we had no default Vim `colorscheme`, which left us at the behest of our terminal. We added a `colorscheme` to our Vim configuration to make it more appealing.
