### PR TITLE
🐛 Fix the `asdf` configuration

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -36,6 +36,8 @@ _load_settings "$HOME/.zsh/configs"
 
 eval "$(/opt/homebrew/bin/brew shellenv)"
 
+export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
+
 # Local config
 [[ -f ~/.zshrc.local ]] && source ~/.zshrc.local
 


### PR DESCRIPTION
Before, we had not added `asdf` into `PATH`, which meant that macOS was looking for system Ruby and JavaScript. We fixed the configuration by adding the `asdf` shim directory to `PATH` as per [their guides][].

[their guides]: https://web.archive.org/web/20251220054329/https://asdf-vm.com/guide/getting-started.html#_2-configure-asdf
