### PR TITLE
🗑️ Drop the path to the Suspenders template

### DIFF
--- a/railsrc
+++ b/railsrc
@@ -1,4 +1,3 @@
 --database=postgresql
 --skip-test
 --skip-rubocop
--m=https://raw.githubusercontent.com/thoughtbot/suspenders/main/lib/install/web.rb


### PR DESCRIPTION
Before, [Suspenders][] used an application template to set up Rails applications. We have since changed the way that Suspenders creates applications. The template no longer existed, but we still referenced it in our Rails configuration. People creating Rails applications with that configuration would get an error. We removed the path to the Suspenders template because it no longer exists and is no longer needed.

[GitHub](https://github.com/thoughtbot/dotfiles/issues/772)

[suspenders]: https://github.com/thoughtbot/suspenders
