### PR TITLE
♻️ Refactor the `path` alias

### DIFF
--- a/aliases
+++ b/aliases
@@ -13,7 +13,7 @@ alias migrate="bin/rails db:migrate db:rollback && bin/rails db:migrate db:test:
 alias s="rspec"
 
 # Pretty print the path
-alias path='echo $PATH | tr -s ":" "\n"'
+alias path='echo -e ${PATH//:/\\n}'
 
 # Easier navigation: ..., ...., ....., and -
 alias ...="cd ../.."


### PR DESCRIPTION
Before, we called out to `tr` when pretty-printing `PATH` via the `path` alias. There was no need for us to do this because we could have used Bash substitution instead. We refactored the `path` alias to do so.

[GitHub](https://github.com/thoughtbot/dotfiles/issues/770)
