### PR TITLE
♻️ Refactor Z shell's history length

### DIFF
--- a/zsh/configs/history.zsh
+++ b/zsh/configs/history.zsh
@@ -3,7 +3,7 @@
 setopt hist_ignore_all_dups hist_ignore_space inc_append_history share_history
 
 HISTFILE=~/.zhistory
-HISTSIZE=8192
-SAVEHIST=8192
+HISTSIZE=32768
+SAVEHIST="${HISTSIZE}"
 
 export ERL_AFLAGS="-kernel shell_history enabled"


### PR DESCRIPTION
Before, we changed Z shell's history to a bigger number, which was okay, but we can go even bigger! We refactored Z shell's history to include 32768 (2^15) entries

- Refactored the save history always to match.
