### PR TITLE
🐛 Fix the `fzf` configuration

### DIFF
--- a/zsh/configs/fzf.zsh
+++ b/zsh/configs/fzf.zsh
@@ -1,3 +1,7 @@
 #!/usr/bin/env zsh
 
-source <(/opt/homebrew/bin/fzf --zsh)
+if command -v fzf > /dev/null; then
+  source <(fzf --zsh)
+elif [[ -x ~/.fzf/bin/fzf ]]; then
+  source <(~/.fzf/bin/fzf --zsh)
+fi


### PR DESCRIPTION
Check if `fzf` is in PATH before falling back to the vim-plug installation location at `~/.fzf/bin/fzf`. This removes the assumption that `fzf` is installed via Homebrew.

Closes #779
