### PR TITLE
Detect Homebrew location for Intel support

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -34,7 +34,11 @@ _load_settings() {
 }
 _load_settings "$HOME/.zsh/configs"
 
-eval "$(/opt/homebrew/bin/brew shellenv)"
+if [ -x /opt/homebrew/bin/brew ]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [ -x /usr/local/bin/brew ]; then
+  eval "$(/usr/local/bin/brew shellenv)"
+fi
 
 export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 


### PR DESCRIPTION
## Summary

- Fixes the hardcoded `/opt/homebrew/bin/brew` path that only works on Apple Silicon Macs
- Checks for Homebrew at `/opt/homebrew/bin/brew` (Apple Silicon) and `/usr/local/bin/brew` (Intel) before eval-ing `shellenv`

Closes #781