### PR TITLE
Update `b` command alias to `bundle install`

### DIFF
--- a/aliases
+++ b/aliases
@@ -6,7 +6,7 @@ alias e="$EDITOR"
 alias v="$VISUAL"
 
 # Bundler
-alias b="bundle"
+alias b="bundle install"
 
 # Rails
 alias migrate="bin/rails db:migrate db:rollback && bin/rails db:migrate db:test:prepare"


### PR DESCRIPTION
Running `bundle` on recent versions of Bundler shows a deprecation warning:

    In a future version of Bundler, running `bundle` without argument will no longer run `bundle install`.
    Instead, the `cli_help` command will be displayed. Please use `bundle install` explicitly for scripts like CI/CD.
    You can use the future behavior now with `bundle config set default_cli_command cli_help --global`,
    or you can continue to use the current behavior with `bundle config set default_cli_command install --global`.
    This message will be removed after a default_cli_command value is set.