### PR TITLE
Add Claude Code's local settings to gitignore

### DIFF
--- a/gitignore
+++ b/gitignore
@@ -14,3 +14,5 @@ log/*.log
 rerun.txt
 tmp/**/*
 /tags
+
+**/.claude/settings.local.json


### PR DESCRIPTION
Claude Code is a coding tool. It writes a file called
`.claude/settings.local.json` into whatever project you run it in. That
file holds settings for one person on one machine. It records which
commands that person has let the tool run, and where things live on
their disk. Nobody else needs it.

Today the file shows up as a new file in `git status` in every project
where the tool has been used. That makes it easy to add to a commit by
mistake. In a client project, one person's settings would then be
shared with the whole team.

The pattern goes in the shared `gitignore` file. The `gitconfig` file
already points git at it for every project on the machine, so one line
here covers them all. It starts working as soon as `rcup` runs.

The rest of the `.claude` folder is left alone. Files a team does want
to share, such as `settings.json` and `CLAUDE.md`, stay tracked. That
split is why the local file has `.local` in its name.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>