### PR TITLE
Add Claude Code's working files to gitignore

### DIFF
--- a/gitignore
+++ b/gitignore
@@ -14,3 +14,14 @@ log/*.log
 rerun.txt
 tmp/**/*
 /tags
+
+**/.claude/scheduled_tasks.lock
+**/.claude/scheduled_tasks.json
+**/.claude/routines/.state/
+**/.claude/worktrees/
+**/.claude/checkpoints/
+**/.claude/mailbox/
+**/.claude/agent-registry.json
+**/.claude/agent-memory-local
+**/.claude/first-run
+**/.claude/assistant-daemon-state.json


### PR DESCRIPTION
Claude Code keeps notes to itself while it runs. It puts them in a
`.claude` folder inside whatever project it is working in. The notes
track things like which jobs are waiting, which helpers are running,
and where its spare copies of the project sit. They belong to one run
on one machine, so they mean nothing to anyone else.

Nothing in this repo covers these names yet. A sweep of one developer's
projects found two of them sitting untracked. That is not many, but the
cost of missing one is a commit full of somebody else's local state.

The names come from watching what the tool writes, not from a manual,
so a later version of the tool may rename them. If that happens these
lines do no harm, because git quietly skips a pattern that matches
nothing.

The `settings.local.json` file is covered on its own in #787. That one
is written up in the tool's manual and turns up far more often, so it
is worth keeping the two changes apart.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>