### PR TITLE
Clear a port held by more than one process

### DIFF
--- a/bin/clear-port
+++ b/bin/clear-port
@@ -1,14 +1,13 @@
 #!/bin/sh
 
-# Kills the process running on the provided port
+# Kills the processes listening on the provided port
 #
 # clear-port 3000
 
 if [ -n "$1" ]; then
-  port_num="$(lsof -ti4TCP:"$1")"
-  if [ $? -eq 0 ]; then
-    kill "$port_num"
-  fi
+  # A port can be held by more than one process, and a forked server's workers
+  # die with the parent, so signal every PID in a single kill.
+  lsof -ti4TCP:"$1" -sTCP:LISTEN | xargs -r kill
 else
   echo >&2 Usage: clear-port port-number
   exit 1


### PR DESCRIPTION
`clear-port` killed nothing when more than one process held the port:

    kill: `453236
    785863': not a pid or valid job spec

`lsof` prints one PID per line, and quoting the result handed the whole list to `kill` as a single argument. Piping the PIDs into `xargs` gives each one an argument of its own.

They go out in a single `kill` rather than one at a time. A forked server shares its listening socket with every worker, so the parent and the workers all appear in the LISTEN list, and the parent tears its workers down as soon as it is signalled. Signalling one PID at a time would reach those workers after they had already gone and report `No such process` for a run that worked.

More than one process is the ordinary case rather than an edge case, because `lsof -ti4TCP:PORT` matches established connections as well as listeners, so a browser with the page open is listed alongside the server it is talking to. `-sTCP:LISTEN` narrows the match to the listening process, which is both what the script sets out to kill and what stops the browser being killed once `kill` starts working.

The pipe into `xargs` is preferred to an unquoted `$(...)`, which batches just as well but trips SC2086 and runs `kill` with no arguments when the port is free. `-r` covers that last case on GNU `xargs`, and is a documented no-op on the BSD `xargs` that ships with macOS.
